### PR TITLE
fix: remove name label to prevent length issues

### DIFF
--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -32,8 +32,6 @@ const (
 const (
 	labelsConfKey = "labels"
 
-	labelName         = "name"
-	labelProject      = "project"
 	labelDeployment   = "deployment"
 	labelOrchestrator = "orchestrator"
 
@@ -100,8 +98,6 @@ func (fd *firehoseDriver) getHelmRelease(res resource.Resource, conf Config) (*h
 	}
 
 	entropyLabels := map[string]string{
-		labelName:         res.Name,
-		labelProject:      res.Project,
 		labelDeployment:   conf.DeploymentID,
 		labelOrchestrator: orchestratorLabelValue,
 	}

--- a/modules/firehose/module.go
+++ b/modules/firehose/module.go
@@ -86,10 +86,9 @@ var Module = module.Descriptor{
 					}
 
 					isManagedByEntropy := curLabels[labelOrchestrator] == orchestratorLabelValue
-					isSameProject := curLabels[labelProject] == newLabels[labelProject]
-					isSameName := curLabels[labelName] == newLabels[labelName]
+					isSameDeployment := curLabels[labelDeployment] == newLabels[labelDeployment]
 
-					return isManagedByEntropy && isSameProject && isSameName
+					return isManagedByEntropy && isSameDeployment
 				}
 
 				helmCl := helm.NewClient(&helm.Config{Kubernetes: kubeConf})


### PR DESCRIPTION
Removes `name` and `project` labels. Relies on `orchestrator: entropy` and `deployment` label to correlate releases.