### PR TITLE
feat: add toleration to kube module config

### DIFF
--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -71,15 +71,15 @@ type (
 )
 
 type driverConf struct {
-	Labels                       map[string]string            `json:"labels,omitempty"`
-	Telegraf                     *Telegraf                    `json:"telegraf"`
-	Namespace                    string                       `json:"namespace" validate:"required"`
-	ChartValues                  ChartValues                  `json:"chart_values" validate:"required"`
-	Limits                       UsageSpec                    `json:"limits,omitempty" validate:"required"`
-	Requests                     UsageSpec                    `json:"requests,omitempty" validate:"required"`
-	Tolerations                  map[string]Toleration        `json:"tolerations"`
-	InitContainer                InitContainer                `json:"init_container"`
-	NodeAffinityMatchExpressions NodeAffinityMatchExpressions `json:"node_affinity_match_expressions"`
+	Labels                       map[string]string                `json:"labels,omitempty"`
+	Telegraf                     *Telegraf                        `json:"telegraf"`
+	Namespace                    string                           `json:"namespace" validate:"required"`
+	ChartValues                  ChartValues                      `json:"chart_values" validate:"required"`
+	Limits                       UsageSpec                        `json:"limits,omitempty" validate:"required"`
+	Requests                     UsageSpec                        `json:"requests,omitempty" validate:"required"`
+	Tolerations                  map[string]kubernetes.Toleration `json:"tolerations"`
+	InitContainer                InitContainer                    `json:"init_container"`
+	NodeAffinityMatchExpressions NodeAffinityMatchExpressions     `json:"node_affinity_match_expressions"`
 
 	GCSSinkCredential      string `json:"gcs_sink_credential,omitempty"`
 	DLQGCSSinkCredential   string `json:"dlq_gcs_sink_credential,omitempty"`
@@ -111,13 +111,6 @@ type InitContainer struct {
 	Repository string `json:"repository"`
 	ImageTag   string `json:"image_tag"`
 	PullPolicy string `json:"pull_policy"`
-}
-
-type Toleration struct {
-	Key      string `json:"key"`
-	Value    string `json:"value"`
-	Effect   string `json:"effect"`
-	Operator string `json:"operator"`
 }
 
 type UsageSpec struct {

--- a/modules/kubernetes/driver.go
+++ b/modules/kubernetes/driver.go
@@ -12,10 +12,8 @@ import (
 	"github.com/goto/entropy/pkg/kube"
 )
 
-const tolerationKey = "tolerations"
-
 type kubeDriver struct {
-	Configs json.RawMessage `json:"configs"`
+	Tolerations map[string][]Toleration
 }
 
 func (m *kubeDriver) Plan(ctx context.Context, res module.ExpandedResource,
@@ -65,19 +63,9 @@ func (m *kubeDriver) Output(_ context.Context, res module.ExpandedResource) (jso
 		return nil, errors.ErrInvalid.WithMsgf("failed to fetch server info: %v", err)
 	}
 
-	configs := map[string]map[string][]Toleration{}
-	err = json.Unmarshal(m.Configs, &configs)
-	if err != nil {
-		return nil, errors.ErrInvalid.WithMsgf("failed to unmarshal module config: %v", err)
-	}
-
-	output := Output{
-		Configs:    conf,
-		ServerInfo: *info,
-	}
-	if configs[tolerationKey] != nil {
-		output.Tolerations = configs[tolerationKey]
-	}
-
-	return output.JSON(), nil
+	return Output{
+		Configs:     conf,
+		ServerInfo:  *info,
+		Tolerations: m.Tolerations,
+	}.JSON(), nil
 }

--- a/modules/kubernetes/driver.go
+++ b/modules/kubernetes/driver.go
@@ -13,7 +13,7 @@ import (
 )
 
 type kubeDriver struct {
-	Tolerations map[string][]Toleration
+	Tolerations map[string][]Toleration `json:"tolerations"`
 }
 
 func (m *kubeDriver) Plan(ctx context.Context, res module.ExpandedResource,

--- a/modules/kubernetes/module.go
+++ b/modules/kubernetes/module.go
@@ -8,8 +8,6 @@ import (
 	"github.com/goto/entropy/pkg/errors"
 )
 
-const tolerationKey = "tolerations"
-
 var Module = module.Descriptor{
 	Kind: "kubernetes",
 	Actions: []module.ActionDesc{

--- a/modules/kubernetes/module.go
+++ b/modules/kubernetes/module.go
@@ -21,18 +21,11 @@ var Module = module.Descriptor{
 		},
 	},
 	DriverFactory: func(conf json.RawMessage) (module.Driver, error) {
-		configs := map[string]map[string][]Toleration{}
-		err := json.Unmarshal(conf, &configs)
+		kd := &kubeDriver{}
+		err := json.Unmarshal(conf, &kd)
 		if err != nil {
 			return nil, errors.ErrInvalid.WithMsgf("failed to unmarshal module config: %v", err)
 		}
-
-		kd := &kubeDriver{}
-
-		if configs[tolerationKey] != nil {
-			kd.Tolerations = configs[tolerationKey]
-		}
-
 		return kd, nil
 	},
 }

--- a/modules/kubernetes/module.go
+++ b/modules/kubernetes/module.go
@@ -18,6 +18,8 @@ var Module = module.Descriptor{
 		},
 	},
 	DriverFactory: func(conf json.RawMessage) (module.Driver, error) {
-		return &kubeDriver{}, nil
+		return &kubeDriver{
+			Configs: conf,
+		}, nil
 	},
 }


### PR DESCRIPTION
The post body can have `toleration` config for `kubernetes` module

```
{
    "configs": {
        "tolerations": {
            "firehose_bigquery": [{
                "key": "example-key",
                "operator": "Lt",
                "value": "5",
                "effect": "NoSchedule"
            }, {
                "key": "example-key-2",
                "operator": "Lt",
                "value": "5",
                "effect": "NoSchedule"
            }]
        }
    },
    "name": "kubernetes",
    "project": "project-001"
}
```

