### PR TITLE
feat: add firehose base config

### DIFF
--- a/modules/firehose/config.go
+++ b/modules/firehose/config.go
@@ -79,6 +79,8 @@ func readConfig(r resource.Resource, confJSON json.RawMessage, dc driverConf) (*
 		return nil, errors.ErrInvalid.WithMsgf("invalid config json").WithCausef(err.Error())
 	}
 
+	cfg.EnvVariables = cloneAndMergeMaps(dc.EnvVariables, cfg.EnvVariables)
+
 	if cfg.Replicas <= 0 {
 		cfg.Replicas = 1
 	}

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -93,6 +93,8 @@ type driverConf struct {
 	// The key in the map is the sink-type in upper case.
 	Tolerations map[string]kubernetes.Toleration `json:"tolerations"`
 
+	EnvVariables map[string]string `json:"env_variables,omitempty"`
+
 	// InitContainer can be set to have a container that is used as init_container on the
 	// deployment.
 	InitContainer InitContainer `json:"init_container"`


### PR DESCRIPTION
User can now add some base configs while registering the firehose module for a project. User-defined values will be merged with the base config values to generate the final configs. This shall also be persisted in the entropy db.