### PR TITLE
fix: remove skipping empty values for env variables

### DIFF
--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -340,7 +340,7 @@ func renderTpl(labelsTpl map[string]string, labelsValues map[string]string) (map
 				WithMsgf("failed to render label template").WithCausef(err.Error())
 		}
 
-		//allow empty values
+		// allow empty values
 		//		labelVal := strings.TrimSpace(buf.String())
 		//		if labelVal == "" {
 		//			continue

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -340,10 +340,11 @@ func renderTpl(labelsTpl map[string]string, labelsValues map[string]string) (map
 				WithMsgf("failed to render label template").WithCausef(err.Error())
 		}
 
-		labelVal := strings.TrimSpace(buf.String())
-		if labelVal == "" {
-			continue
-		}
+		//allow empty values
+		//		labelVal := strings.TrimSpace(buf.String())
+		//		if labelVal == "" {
+		//			continue
+		//		}
 
 		finalLabels[k] = buf.String()
 	}


### PR DESCRIPTION
remove skipping empty values in renderTpl method, since it's skipping  env variables with empty values