### PR TITLE
feat: return only running & non-terminating pods

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -287,6 +287,11 @@ func (c Client) GetPodDetails(ctx context.Context, namespace string, labelSelect
 	}
 
 	for _, pod := range pods.Items {
+		// not listing pods that are not in running state or are about to terminate
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+			continue
+		}
+
 		podDetail := Pod{
 			Name: pod.Name,
 		}


### PR DESCRIPTION
- skip pods in output if they are not in running state or in pending state