### PR TITLE
fix: add delay before executing reset

### DIFF
--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -75,7 +75,7 @@ type firehoseDriver struct {
 type (
 	kubeDeployFn    func(ctx context.Context, isCreate bool, conf kube.Config, hc helm.ReleaseConfig) error
 	kubeGetPodFn    func(ctx context.Context, conf kube.Config, ns string, labels map[string]string) ([]kube.Pod, error)
-	consumerResetFn func(ctx context.Context, conf Config, out kubernetes.Output, resetTo string) error
+	consumerResetFn func(ctx context.Context, conf Config, out kubernetes.Output, resetTo string, offsetResetDelaySeconds int) error
 )
 
 type driverConf struct {

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -119,7 +119,7 @@ type driverConf struct {
 	// NodeAffinityMatchExpressions can be used to set node-affinity for the deployment.
 	NodeAffinityMatchExpressions NodeAffinityMatchExpressions `json:"node_affinity_match_expressions"`
 
-	//delay after stopping a firehose, for making an offset reset request
+	//delay between stopping a firehose and making an offset reset request
 	OffsetResetDelay time.Duration `json:"offset_reset_delay"`
 }
 

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -118,6 +118,9 @@ type driverConf struct {
 
 	// NodeAffinityMatchExpressions can be used to set node-affinity for the deployment.
 	NodeAffinityMatchExpressions NodeAffinityMatchExpressions `json:"node_affinity_match_expressions"`
+
+	//delay after stopping a firehose, for making an offset reset request
+	OffsetResetDelay time.Duration `json:"offset_reset_delay"`
 }
 
 type RequestsAndLimits struct {

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -120,7 +120,7 @@ type driverConf struct {
 	NodeAffinityMatchExpressions NodeAffinityMatchExpressions `json:"node_affinity_match_expressions"`
 
 	// delay between stopping a firehose and making an offset reset request
-	OffsetResetDelay time.Duration `json:"offset_reset_delay"`
+	OffsetResetDelaySeconds int `json:"offset_reset_delay_seconds"`
 }
 
 type RequestsAndLimits struct {

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -119,7 +119,7 @@ type driverConf struct {
 	// NodeAffinityMatchExpressions can be used to set node-affinity for the deployment.
 	NodeAffinityMatchExpressions NodeAffinityMatchExpressions `json:"node_affinity_match_expressions"`
 
-	//delay between stopping a firehose and making an offset reset request
+	// delay between stopping a firehose and making an offset reset request
 	OffsetResetDelay time.Duration `json:"offset_reset_delay"`
 }
 

--- a/modules/firehose/driver_sync.go
+++ b/modules/firehose/driver_sync.go
@@ -11,8 +11,6 @@ import (
 	"github.com/goto/entropy/pkg/errors"
 )
 
-const SleepDurationBeforeReset = 10
-
 func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource) (*resource.State, error) {
 	modData, err := readTransientData(exr)
 	if err != nil {
@@ -59,7 +57,7 @@ func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource)
 			}
 
 		case stepKafkaReset:
-			time.Sleep(SleepDurationBeforeReset * time.Second)
+			time.Sleep(fd.conf.OffsetResetDelay)
 			if err := fd.consumerReset(ctx, *conf, kubeOut, modData.ResetOffsetTo); err != nil {
 				return nil, err
 			}

--- a/modules/firehose/driver_sync.go
+++ b/modules/firehose/driver_sync.go
@@ -3,12 +3,15 @@ package firehose
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/goto/entropy/core/module"
 	"github.com/goto/entropy/core/resource"
 	"github.com/goto/entropy/modules/kubernetes"
 	"github.com/goto/entropy/pkg/errors"
 )
+
+const SleepDurationBeforeReset = 10
 
 func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource) (*resource.State, error) {
 	modData, err := readTransientData(exr)
@@ -56,6 +59,7 @@ func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource)
 			}
 
 		case stepKafkaReset:
+			time.Sleep(SleepDurationBeforeReset * time.Second)
 			if err := fd.consumerReset(ctx, *conf, kubeOut, modData.ResetOffsetTo); err != nil {
 				return nil, err
 			}

--- a/modules/firehose/driver_sync.go
+++ b/modules/firehose/driver_sync.go
@@ -3,7 +3,6 @@ package firehose
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/goto/entropy/core/module"
 	"github.com/goto/entropy/core/resource"
@@ -57,8 +56,7 @@ func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource)
 			}
 
 		case stepKafkaReset:
-			time.Sleep(time.Duration(fd.conf.OffsetResetDelaySeconds) * time.Second)
-			if err := fd.consumerReset(ctx, *conf, kubeOut, modData.ResetOffsetTo); err != nil {
+			if err := fd.consumerReset(ctx, *conf, kubeOut, modData.ResetOffsetTo, fd.conf.OffsetResetDelaySeconds); err != nil {
 				return nil, err
 			}
 

--- a/modules/firehose/driver_sync.go
+++ b/modules/firehose/driver_sync.go
@@ -57,7 +57,7 @@ func (fd *firehoseDriver) Sync(ctx context.Context, exr module.ExpandedResource)
 			}
 
 		case stepKafkaReset:
-			time.Sleep(fd.conf.OffsetResetDelay)
+			time.Sleep(time.Duration(fd.conf.OffsetResetDelaySeconds) * time.Second)
 			if err := fd.consumerReset(ctx, *conf, kubeOut, modData.ResetOffsetTo); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
- kafka takes some time before it registers the stopped consumer
- hence when we try to attempt the reset immediately, it fails
- even though it fails, it does not return a failed response
- adding a delay of 10 seconds before performing reset