### PR TITLE
feat: add sink based kube namespace selection

### DIFF
--- a/modules/firehose/config.go
+++ b/modules/firehose/config.go
@@ -122,5 +122,13 @@ func readConfig(r resource.Resource, confJSON json.RawMessage, dc driverConf) (*
 	cfg.Limits = rl.Limits.merge(cfg.Limits)
 	cfg.Requests = rl.Requests.merge(cfg.Requests)
 
+	if cfg.Namespace == "" {
+		ns := dc.Namespace[defaultKey]
+		if override, ok := dc.Namespace[cfg.EnvVariables[confSinkType]]; ok {
+			ns = override
+		}
+		cfg.Namespace = ns
+	}
+
 	return &cfg, nil
 }

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -38,6 +38,7 @@ const (
 	labelOrchestrator = "orchestrator"
 	labelURN          = "urn"
 	labelName         = "name"
+	labelNamespace    = "namespace"
 
 	orchestratorLabelValue = "entropy"
 )
@@ -185,11 +186,12 @@ func (fd *firehoseDriver) getHelmRelease(res resource.Resource, conf Config,
 	}
 
 	otherLabels := map[string]string{
-		labelURN:  res.URN,
-		labelName: res.Name,
+		labelURN:       res.URN,
+		labelName:      res.Name,
+		labelNamespace: conf.Namespace,
 	}
 
-	deploymentLabels, err := renderTpl(fd.conf.Labels, modules.CloneAndMergeMaps(res.Labels, entropyLabels))
+	deploymentLabels, err := renderTpl(fd.conf.Labels, modules.CloneAndMergeMaps(res.Labels, modules.CloneAndMergeMaps(entropyLabels, otherLabels)))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -45,7 +45,9 @@ const (
 const defaultKey = "default"
 
 var defaultDriverConf = driverConf{
-	Namespace: "firehose",
+	Namespace: map[string]string{
+		defaultKey: "firehose",
+	},
 	ChartValues: ChartValues{
 		ImageTag:        "latest",
 		ChartVersion:    "0.1.3",
@@ -87,7 +89,7 @@ type driverConf struct {
 	Telegraf *Telegraf `json:"telegraf"`
 
 	// Namespace is the kubernetes namespace where firehoses will be deployed.
-	Namespace string `json:"namespace" validate:"required"`
+	Namespace map[string]string `json:"namespace" validate:"required"`
 
 	// ChartValues is the chart and image version information.
 	ChartValues ChartValues `json:"chart_values" validate:"required"`

--- a/modules/firehose/driver_output.go
+++ b/modules/firehose/driver_output.go
@@ -43,6 +43,7 @@ func (fd *firehoseDriver) refreshOutput(ctx context.Context, r resource.Resource
 		return nil, errors.ErrInternal.WithCausef(err.Error())
 	}
 	output.Pods = pods
+	output.Namespace = conf.Namespace
 
 	return modules.MustJSON(output), nil
 }

--- a/modules/firehose/driver_plan.go
+++ b/modules/firehose/driver_plan.go
@@ -20,7 +20,7 @@ var (
 	suffixRegex = regexp.MustCompile(`^([A-Za-z0-9-]+)-([0-9]+)$`)
 )
 
-var ErrMsgInvalidNamespaceUpdate = "cannot update kube namespace of a running firehose"
+var errCauseInvalidNamespaceUpdate = "cannot update kube namespace of a running firehose"
 
 func (fd *firehoseDriver) Plan(_ context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	switch act.Name {
@@ -68,7 +68,7 @@ func (fd *firehoseDriver) planChange(exr module.ExpandedResource, act module.Act
 		}
 		if curConf.Namespace != ns {
 			if !curConf.Stopped {
-				return nil, errors.ErrInvalid.WithCausef(ErrMsgInvalidNamespaceUpdate)
+				return nil, errors.ErrInvalid.WithCausef(errCauseInvalidNamespaceUpdate)
 			}
 			newConf.Namespace = ns
 		}

--- a/modules/firehose/driver_plan.go
+++ b/modules/firehose/driver_plan.go
@@ -20,6 +20,8 @@ var (
 	suffixRegex = regexp.MustCompile(`^([A-Za-z0-9-]+)-([0-9]+)$`)
 )
 
+var ErrInvalidNamespaceUpdate = errors.New("cannot update kube namespace of a running firehose")
+
 func (fd *firehoseDriver) Plan(_ context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	switch act.Name {
 	case module.CreateAction:
@@ -57,9 +59,19 @@ func (fd *firehoseDriver) planChange(exr module.ExpandedResource, act module.Act
 		// restore configs that are not user-controlled.
 		newConf.DeploymentID = curConf.DeploymentID
 		newConf.ChartValues = chartVals
-		newConf.Namespace = curConf.Namespace
 		newConf.Telegraf = fd.conf.Telegraf
 		newConf.InitContainer = fd.conf.InitContainer
+
+		ns := fd.conf.Namespace[defaultKey]
+		if override, ok := fd.conf.Namespace[newConf.EnvVariables[confSinkType]]; ok {
+			ns = override
+		}
+		if curConf.Namespace != ns {
+			if !newConf.Stopped {
+				return nil, errors.ErrInvalid.WithMsgf(ErrInvalidNamespaceUpdate.Error())
+			}
+			newConf.Namespace = ns
+		}
 
 		curConf = newConf
 
@@ -120,7 +132,6 @@ func (fd *firehoseDriver) planCreate(exr module.ExpandedResource, act module.Act
 
 	// set project defaults.
 	conf.Telegraf = fd.conf.Telegraf
-	conf.Namespace = fd.conf.Namespace
 	conf.ChartValues = chartVals
 
 	immediately := fd.timeNow()

--- a/modules/firehose/driver_plan.go
+++ b/modules/firehose/driver_plan.go
@@ -20,7 +20,7 @@ var (
 	suffixRegex = regexp.MustCompile(`^([A-Za-z0-9-]+)-([0-9]+)$`)
 )
 
-var ErrInvalidNamespaceUpdate = errors.New("cannot update kube namespace of a running firehose")
+var ErrMsgInvalidNamespaceUpdate = "cannot update kube namespace of a running firehose"
 
 func (fd *firehoseDriver) Plan(_ context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	switch act.Name {
@@ -68,7 +68,7 @@ func (fd *firehoseDriver) planChange(exr module.ExpandedResource, act module.Act
 		}
 		if curConf.Namespace != ns {
 			if !curConf.Stopped {
-				return nil, errors.ErrInvalid.WithMsgf(ErrInvalidNamespaceUpdate.Error())
+				return nil, errors.ErrInvalid.WithCausef(ErrMsgInvalidNamespaceUpdate)
 			}
 			newConf.Namespace = ns
 		}

--- a/modules/firehose/driver_plan.go
+++ b/modules/firehose/driver_plan.go
@@ -67,7 +67,7 @@ func (fd *firehoseDriver) planChange(exr module.ExpandedResource, act module.Act
 			ns = override
 		}
 		if curConf.Namespace != ns {
-			if !newConf.Stopped {
+			if !curConf.Stopped {
 				return nil, errors.ErrInvalid.WithMsgf(ErrInvalidNamespaceUpdate.Error())
 			}
 			newConf.Namespace = ns

--- a/modules/firehose/driver_plan_test.go
+++ b/modules/firehose/driver_plan_test.go
@@ -186,6 +186,77 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			title: "Create_ValidRequest_Bigquery",
+			exr: module.ExpandedResource{
+				Resource: resource.Resource{
+					URN:     "urn:goto:entropy:foo:fh1",
+					Kind:    "firehose",
+					Name:    "fh1",
+					Project: "foo",
+				},
+			},
+			act: module.ActionRequest{
+				Name: module.CreateAction,
+				Params: modules.MustJSON(map[string]any{
+					"replicas": 1,
+					"env_variables": map[string]string{
+						"SINK_TYPE":                      "BIGQUERY",
+						"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
+						"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
+						"SOURCE_KAFKA_BROKERS":           "localhost:9092",
+						"SOURCE_KAFKA_TOPIC":             "foo-log",
+					},
+				}),
+			},
+			want: &resource.Resource{
+				URN:     "urn:goto:entropy:foo:fh1",
+				Kind:    "firehose",
+				Name:    "fh1",
+				Project: "foo",
+				Spec: resource.Spec{
+					Configs: modules.MustJSON(map[string]any{
+						"stopped":       false,
+						"replicas":      1,
+						"namespace":     "bigquery-firehose",
+						"deployment_id": "foo-fh1-firehose",
+						"chart_values": map[string]string{
+							"chart_version":     "0.1.3",
+							"image_pull_policy": "IfNotPresent",
+							"image_tag":         "latest",
+						},
+						"limits": map[string]any{
+							"cpu":    "200m",
+							"memory": "512Mi",
+						},
+						"requests": map[string]any{
+							"cpu":    "200m",
+							"memory": "512Mi",
+						},
+						"env_variables": map[string]string{
+							"SINK_TYPE":                      "BIGQUERY",
+							"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
+							"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
+							"SOURCE_KAFKA_BROKERS":           "localhost:9092",
+							"SOURCE_KAFKA_TOPIC":             "foo-log",
+						},
+						"init_container": map[string]interface{}{"args": interface{}(nil), "command": interface{}(nil), "enabled": false, "image_tag": "", "pull_policy": "", "repository": ""},
+					}),
+				},
+				State: resource.State{
+					Status: resource.StatusPending,
+					Output: modules.MustJSON(Output{
+						Namespace:   "bigquery-firehose",
+						ReleaseName: "foo-fh1-firehose",
+					}),
+					ModuleData: modules.MustJSON(transientData{
+						PendingSteps: []string{stepReleaseCreate},
+					}),
+					NextSyncAt: &frozenTime,
+				},
+			},
+			wantErr: nil,
+		},
 
 		// update action tests
 		{
@@ -211,7 +282,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 					State: resource.State{
 						Status: resource.StatusCompleted,
 						Output: modules.MustJSON(Output{
-							Namespace:   "foo",
+							Namespace:   "firehose",
 							ReleaseName: "bar",
 						}),
 					},
@@ -237,6 +308,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Project: "foo",
 				Spec: resource.Spec{
 					Configs: modules.MustJSON(map[string]any{
+						"namespace":     "firehose",
 						"stopped":       false,
 						"replicas":      10,
 						"deployment_id": "firehose-deployment-x",
@@ -261,7 +333,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				State: resource.State{
 					Status: resource.StatusPending,
 					Output: modules.MustJSON(Output{
-						Namespace:   "foo",
+						Namespace:   "firehose",
 						ReleaseName: "bar",
 					}),
 					ModuleData: modules.MustJSON(transientData{
@@ -272,7 +344,6 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 			},
 			wantErr: nil,
 		},
-
 		{
 			title: "Update_Resource_&_Limits",
 			exr: module.ExpandedResource{
@@ -296,7 +367,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 					State: resource.State{
 						Status: resource.StatusCompleted,
 						Output: modules.MustJSON(Output{
-							Namespace:   "foo",
+							Namespace:   "firehose",
 							ReleaseName: "bar",
 						}),
 					},
@@ -330,6 +401,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Project: "foo",
 				Spec: resource.Spec{
 					Configs: modules.MustJSON(map[string]any{
+						"namespace":     "firehose",
 						"stopped":       false,
 						"replicas":      10,
 						"deployment_id": "firehose-deployment-x",
@@ -354,7 +426,142 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				State: resource.State{
 					Status: resource.StatusPending,
 					Output: modules.MustJSON(Output{
-						Namespace:   "foo",
+						Namespace:   "firehose",
+						ReleaseName: "bar",
+					}),
+					ModuleData: modules.MustJSON(transientData{
+						PendingSteps: []string{stepReleaseUpdate},
+					}),
+					NextSyncAt: &frozenTime,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			title: "Update_Running_Firehose_Namespace",
+			exr: module.ExpandedResource{
+				Resource: resource.Resource{
+					URN:     "urn:goto:entropy:foo:fh1",
+					Kind:    "firehose",
+					Name:    "fh1",
+					Project: "foo",
+					Spec: resource.Spec{
+						Configs: modules.MustJSON(map[string]any{
+							"replicas":      1,
+							"stopped":       false,
+							"deployment_id": "firehose-deployment-x",
+							"env_variables": map[string]string{
+								"SINK_TYPE":                "LOG",
+								"INPUT_SCHEMA_PROTO_CLASS": "com.foo.Bar",
+								"SOURCE_KAFKA_BROKERS":     "localhost:9092",
+								"SOURCE_KAFKA_TOPIC":       "foo-log",
+							},
+						}),
+					},
+					State: resource.State{
+						Status: resource.StatusCompleted,
+						Output: modules.MustJSON(Output{
+							Namespace:   "firehose",
+							ReleaseName: "bar",
+						}),
+					},
+				},
+			},
+			act: module.ActionRequest{
+				Name: module.UpdateAction,
+				Params: modules.MustJSON(map[string]any{
+					"replicas": 10,
+					"stopped":  false,
+					"env_variables": map[string]string{
+						"SINK_TYPE":                      "BIGQUERY", // the change being applied
+						"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
+						"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
+						"SOURCE_KAFKA_BROKERS":           "localhost:9092",
+						"SOURCE_KAFKA_TOPIC":             "foo-log",
+					},
+				}),
+			},
+			want:    nil,
+			wantErr: errors.ErrInvalid.WithMsgf(ErrInvalidNamespaceUpdate.Error()),
+		},
+		{
+			title: "Update_Stopped_Firehose_Namespace",
+			exr: module.ExpandedResource{
+				Resource: resource.Resource{
+					URN:     "urn:goto:entropy:foo:fh1",
+					Kind:    "firehose",
+					Name:    "fh1",
+					Project: "foo",
+					Spec: resource.Spec{
+						Configs: modules.MustJSON(map[string]any{
+							"namespace":     "firehose",
+							"replicas":      1,
+							"stopped":       true,
+							"deployment_id": "firehose-deployment-x",
+							"env_variables": map[string]string{
+								"SINK_TYPE":                "LOG",
+								"INPUT_SCHEMA_PROTO_CLASS": "com.foo.Bar",
+								"SOURCE_KAFKA_BROKERS":     "localhost:9092",
+								"SOURCE_KAFKA_TOPIC":       "foo-log",
+							},
+						}),
+					},
+					State: resource.State{
+						Status: resource.StatusCompleted,
+						Output: modules.MustJSON(Output{
+							Namespace:   "firehose",
+							ReleaseName: "bar",
+						}),
+					},
+				},
+			},
+			act: module.ActionRequest{
+				Name: module.UpdateAction,
+				Params: modules.MustJSON(map[string]any{
+					"replicas": 10,
+					"stopped":  true,
+					"env_variables": map[string]string{
+						"SINK_TYPE":                      "BIGQUERY", // the change being applied
+						"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
+						"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
+						"SOURCE_KAFKA_BROKERS":           "localhost:9092",
+						"SOURCE_KAFKA_TOPIC":             "foo-log",
+					},
+				}),
+			},
+			want: &resource.Resource{
+				URN:     "urn:goto:entropy:foo:fh1",
+				Kind:    "firehose",
+				Name:    "fh1",
+				Project: "foo",
+				Spec: resource.Spec{
+					Configs: modules.MustJSON(map[string]any{
+						"namespace":     "bigquery-firehose",
+						"stopped":       true,
+						"replicas":      10,
+						"deployment_id": "firehose-deployment-x",
+						"env_variables": map[string]string{
+							"SINK_TYPE":                      "BIGQUERY",
+							"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
+							"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
+							"SOURCE_KAFKA_BROKERS":           "localhost:9092",
+							"SOURCE_KAFKA_TOPIC":             "foo-log",
+						},
+						"limits": map[string]any{
+							"cpu":    "200m",
+							"memory": "512Mi",
+						},
+						"requests": map[string]any{
+							"cpu":    "200m",
+							"memory": "512Mi",
+						},
+						"init_container": map[string]interface{}{"args": interface{}(nil), "command": interface{}(nil), "enabled": false, "image_tag": "", "pull_policy": "", "repository": ""},
+					}),
+				},
+				State: resource.State{
+					Status: resource.StatusPending,
+					Output: modules.MustJSON(Output{
+						Namespace:   "firehose", // this is updated when Output is triggered
 						ReleaseName: "bar",
 					}),
 					ModuleData: modules.MustJSON(transientData{
@@ -438,7 +645,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 					State: resource.State{
 						Status: resource.StatusCompleted,
 						Output: modules.MustJSON(Output{
-							Namespace:   "foo",
+							Namespace:   "firehose",
 							ReleaseName: "bar",
 						}),
 					},
@@ -457,6 +664,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Project: "foo",
 				Spec: resource.Spec{
 					Configs: modules.MustJSON(map[string]any{
+						"namespace":     "firehose",
 						"replicas":      1,
 						"deployment_id": "firehose-deployment-x",
 						"env_variables": map[string]string{
@@ -483,7 +691,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				State: resource.State{
 					Status: resource.StatusPending,
 					Output: modules.MustJSON(Output{
-						Namespace:   "foo",
+						Namespace:   "firehose",
 						ReleaseName: "bar",
 					}),
 					ModuleData: modules.MustJSON(transientData{
@@ -528,7 +736,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 					State: resource.State{
 						Status: resource.StatusCompleted,
 						Output: modules.MustJSON(Output{
-							Namespace:   "foo",
+							Namespace:   "firehose",
 							ReleaseName: "bar",
 						}),
 					},
@@ -544,6 +752,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Project: "foo",
 				Spec: resource.Spec{
 					Configs: modules.MustJSON(map[string]any{
+						"namespace":     "firehose",
 						"stopped":       false,
 						"replicas":      1,
 						"deployment_id": "firehose-deployment-x",
@@ -573,7 +782,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				State: resource.State{
 					Status: resource.StatusPending,
 					Output: modules.MustJSON(Output{
-						Namespace:   "foo",
+						Namespace:   "firehose",
 						ReleaseName: "bar",
 					}),
 					ModuleData: modules.MustJSON(transientData{
@@ -634,6 +843,11 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 			dr := &firehoseDriver{
 				conf:    defaultDriverConf,
 				timeNow: func() time.Time { return frozenTime },
+			}
+
+			dr.conf.Namespace = map[string]string{
+				defaultKey: "firehose",
+				"BIGQUERY": "bigquery-firehose",
 			}
 
 			got, err := dr.Plan(context.Background(), tt.exr, tt.act)

--- a/modules/firehose/driver_plan_test.go
+++ b/modules/firehose/driver_plan_test.go
@@ -482,7 +482,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				}),
 			},
 			want:    nil,
-			wantErr: errors.ErrInvalid.WithCausef(ErrMsgInvalidNamespaceUpdate),
+			wantErr: errors.ErrInvalid.WithCausef(errCauseInvalidNamespaceUpdate),
 		},
 		{
 			title: "Update_Stopped_Firehose_Namespace",

--- a/modules/firehose/driver_plan_test.go
+++ b/modules/firehose/driver_plan_test.go
@@ -482,7 +482,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				}),
 			},
 			want:    nil,
-			wantErr: errors.ErrInvalid.WithMsgf(ErrInvalidNamespaceUpdate.Error()),
+			wantErr: errors.ErrInvalid.WithCausef(ErrMsgInvalidNamespaceUpdate),
 		},
 		{
 			title: "Update_Stopped_Firehose_Namespace",

--- a/modules/firehose/driver_plan_test.go
+++ b/modules/firehose/driver_plan_test.go
@@ -519,7 +519,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Name: module.UpdateAction,
 				Params: modules.MustJSON(map[string]any{
 					"replicas": 10,
-					"stopped":  true,
+					"stopped":  false, // shall allow starting at the time of update
 					"env_variables": map[string]string{
 						"SINK_TYPE":                      "BIGQUERY", // the change being applied
 						"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
@@ -537,7 +537,7 @@ func TestFirehoseDriver_Plan(t *testing.T) {
 				Spec: resource.Spec{
 					Configs: modules.MustJSON(map[string]any{
 						"namespace":     "bigquery-firehose",
-						"stopped":       true,
+						"stopped":       false,
 						"replicas":      10,
 						"deployment_id": "firehose-deployment-x",
 						"env_variables": map[string]string{

--- a/modules/firehose/driver_sync_test.go
+++ b/modules/firehose/driver_sync_test.go
@@ -81,7 +81,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 				ModuleData: modules.MustJSON(transientData{
 					PendingSteps: nil,
 				}),
-			}),
+			}, "LOG", "firehose"),
 			kubeGetPod: func(t *testing.T) kubeGetPodFn {
 				t.Helper()
 				return func(ctx context.Context, conf kube.Config, ns string, labels map[string]string) ([]kube.Pod, error) {
@@ -98,6 +98,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 			want: &resource.State{
 				Status: resource.StatusCompleted,
 				Output: modules.MustJSON(Output{
+					Namespace: "firehose",
 					Pods: []kube.Pod{
 						{
 							Name:       "foo-1",
@@ -113,7 +114,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 			exr: sampleResourceWithState(resource.State{
 				Status: resource.StatusCompleted,
 				Output: modules.MustJSON(Output{}),
-			}),
+			}, "LOG", "firehose"),
 			kubeGetPod: func(t *testing.T) kubeGetPodFn {
 				t.Helper()
 				return func(ctx context.Context, conf kube.Config, ns string, labels map[string]string) ([]kube.Pod, error) {
@@ -130,7 +131,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 				ModuleData: modules.MustJSON(transientData{
 					PendingSteps: []string{stepReleaseCreate},
 				}),
-			}),
+			}, "LOG", "firehose"),
 			kubeDeploy: func(t *testing.T) kubeDeployFn {
 				t.Helper()
 				return func(ctx context.Context, isCreate bool, conf kube.Config, hc helm.ReleaseConfig) error {
@@ -160,7 +161,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 				ModuleData: modules.MustJSON(transientData{
 					PendingSteps: []string{stepReleaseCreate},
 				}),
-			}),
+			}, "LOG", "firehose"),
 			kubeDeploy: func(t *testing.T) kubeDeployFn {
 				t.Helper()
 				return func(ctx context.Context, isCreate bool, conf kube.Config, hc helm.ReleaseConfig) error {
@@ -199,7 +200,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 				ModuleData: modules.MustJSON(transientData{
 					PendingSteps: []string{stepReleaseStop},
 				}),
-			}),
+			}, "LOG", "firehose"),
 			kubeDeploy: func(t *testing.T) kubeDeployFn {
 				t.Helper()
 				return func(ctx context.Context, isCreate bool, conf kube.Config, hc helm.ReleaseConfig) error {
@@ -263,7 +264,7 @@ func TestFirehoseDriver_Sync(t *testing.T) {
 	}
 }
 
-func sampleResourceWithState(state resource.State) module.ExpandedResource {
+func sampleResourceWithState(state resource.State, sinkType, namespace string) module.ExpandedResource {
 	return module.ExpandedResource{
 		Resource: resource.Resource{
 			URN:     "urn:goto:entropy:foo:fh1",
@@ -273,7 +274,7 @@ func sampleResourceWithState(state resource.State) module.ExpandedResource {
 			Spec: resource.Spec{
 				Configs: modules.MustJSON(map[string]any{
 					"replicas":      1,
-					"namespace":     "firehose",
+					"namespace":     namespace,
 					"deployment_id": "firehose-foo-fh1",
 					"telegraf": map[string]any{
 						"enabled": false,
@@ -284,7 +285,7 @@ func sampleResourceWithState(state resource.State) module.ExpandedResource {
 						"image_tag":         "latest",
 					},
 					"env_variables": map[string]string{
-						"SINK_TYPE":                      "LOG",
+						"SINK_TYPE":                      sinkType,
 						"INPUT_SCHEMA_PROTO_CLASS":       "com.foo.Bar",
 						"SOURCE_KAFKA_CONSUMER_GROUP_ID": "foo-bar-baz",
 						"SOURCE_KAFKA_BROKERS":           "localhost:9092",

--- a/modules/firehose/driver_test.go
+++ b/modules/firehose/driver_test.go
@@ -576,7 +576,6 @@ func TestFirehoseDriver(t *testing.T) {
 			chartVals, _ := mergeChartValues(&fd.conf.ChartValues, conf.ChartValues)
 
 			conf.Telegraf = fd.conf.Telegraf
-			conf.Namespace = fd.conf.Namespace
 			conf.ChartValues = chartVals
 
 			got, err := fd.getHelmRelease(tt.res, *conf, tt.kubeOutput)
@@ -641,7 +640,9 @@ func firehoseDriverConf() driverConf {
 		Labels: map[string]string{
 			"team": "{{.team}}",
 		},
-		Namespace: "namespace-1",
+		Namespace: map[string]string{
+			"default": "namespace-1",
+		},
 		RequestsAndLimits: map[string]RequestsAndLimits{
 			"BIGQUERY": {
 				Limits: UsageSpec{


### PR DESCRIPTION
User can now configure different namespaces for each sink type along with a default.
```
"namespace" : {
    "default": "firehose",
    "BIGQUERY": "bigquery-firehose"
}
```

Though users can't change sink which has a different namespace if the firehose is in `running` state. This is to avoid having two running deployments. Otherwise, a deployment would be upserted in the new namespace.

The updated namespace is also reflected in the `Output` after sync is completed. 
