### PR TITLE
feat: templatize telegraf config output

### DIFF
--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -209,19 +209,18 @@ func (fd *firehoseDriver) getHelmRelease(res resource.Resource, conf Config,
 			return nil, err
 		}
 
-		promRemoteWrite, exist := conf.Telegraf.Config.Output["prometheus_remote_write"]
-		if exist {
-			promRemoteWrite, ok := promRemoteWrite.(map[string]interface{})
+		for key, val := range conf.Telegraf.Config.Output {
+			valAsMap, ok := val.(map[string]interface{})
 			if !ok {
-				return nil, errors.New("prometheus_remote_write is not of type map[string]interface")
+				continue
 			}
 
-			promRemoteWrite, err = renderTplOfMapStringAny(promRemoteWrite, mergedLabelsAndEnvVariablesMap)
+			valAsMap, err = renderTplOfMapStringAny(valAsMap, mergedLabelsAndEnvVariablesMap)
 			if err != nil {
 				return nil, err
 			}
 
-			conf.Telegraf.Config.Output["prometheus_remote_write"] = promRemoteWrite
+			conf.Telegraf.Config.Output[key] = valAsMap
 		}
 
 		telegrafConf = Telegraf{

--- a/modules/firehose/driver_test.go
+++ b/modules/firehose/driver_test.go
@@ -181,7 +181,7 @@ func TestFirehoseDriver(t *testing.T) {
 							"output": map[string]any{
 								"prometheus_remote_write": map[string]any{
 									"enabled": true,
-									"url":     "http://goto.com",
+									"url":     "http://goto.namespace-1.com",
 								},
 							},
 							"additional_global_tags": map[string]string{
@@ -358,7 +358,7 @@ func TestFirehoseDriver(t *testing.T) {
 							"output": map[string]any{
 								"prometheus_remote_write": map[string]any{
 									"enabled": true,
-									"url":     "http://goto.com",
+									"url":     "http://goto.namespace-1.com",
 								},
 							},
 							"additional_global_tags": map[string]string{
@@ -543,7 +543,7 @@ func TestFirehoseDriver(t *testing.T) {
 							"output": map[string]any{
 								"prometheus_remote_write": map[string]any{
 									"enabled": true,
-									"url":     "http://goto.com",
+									"url":     "http://goto.namespace-1.com",
 								},
 							},
 							"additional_global_tags": map[string]string{
@@ -686,7 +686,7 @@ func firehoseDriverConf() driverConf {
 				Output: map[string]any{
 					"prometheus_remote_write": map[string]any{
 						"enabled": true,
-						"url":     "http://goto.com",
+						"url":     "http://goto.{{ .namespace }}.com",
 					},
 				},
 				AdditionalGlobalTags: map[string]string{


### PR DESCRIPTION
Allow templatizing in telegraf config output 

example
```
                        "output": {
                            "prometheus_remote_write": {
                                "enabled": true,
                                "url": "http://{{ .namespace }}.com"
                            }
                        }
```