### PR TITLE
feat: make kube deployment timeout, extendInterval etc configurable

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -27,9 +27,11 @@ type Config struct {
 }
 
 type syncerConf struct {
-	SyncInterval    time.Duration `mapstructure:"sync_interval" default:"1s"`
-	RefreshInterval time.Duration `mapstructure:"refresh_interval" default:"3s"`
-	ExtendLockBy    time.Duration `mapstructure:"extend_lock_by" default:"5s"`
+	SyncInterval        time.Duration `mapstructure:"sync_interval" default:"1s"`
+	RefreshInterval     time.Duration `mapstructure:"refresh_interval" default:"3s"`
+	ExtendLockBy        time.Duration `mapstructure:"extend_lock_by" default:"5s"`
+	SyncBackoffInterval time.Duration `mapstructure:"sync_backoff_interval" default:"5s"`
+	MaxRetries          int           `mapstructure:"max_retries" default:"5"`
 }
 
 type serveConfig struct {

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -52,7 +52,7 @@ func cmdServe() *cobra.Command {
 
 		store := setupStorage(cfg.PGConnStr, cfg.Syncer)
 		moduleService := module.NewService(setupRegistry(), store)
-		resourceService := core.New(store, moduleService, time.Now)
+		resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
 
 		if migrate {
 			if migrateErr := runMigrations(cmd.Context(), cfg); migrateErr != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -27,12 +27,7 @@ type ModuleService interface {
 	GetOutput(ctx context.Context, res module.ExpandedResource) (json.RawMessage, error)
 }
 
-func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time) *Service {
-	const (
-		defaultMaxRetries  = 10
-		defaultSyncBackoff = 5 * time.Second
-	)
-
+func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time, syncBackoffInterval time.Duration, maxRetries int) *Service {
 	if clockFn == nil {
 		clockFn = time.Now
 	}
@@ -40,8 +35,8 @@ func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time)
 	return &Service{
 		clock:          clockFn,
 		store:          repo,
-		syncBackoff:    defaultSyncBackoff,
-		maxSyncRetries: defaultMaxRetries,
+		syncBackoff:    syncBackoffInterval,
+		maxSyncRetries: maxRetries,
 		moduleSvc:      moduleSvc,
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -25,6 +25,6 @@ var (
 
 func TestNew(t *testing.T) {
 	t.Parallel()
-	s := core.New(&mocks.ResourceStore{}, &mocks.ModuleService{}, deadClock)
+	s := core.New(&mocks.ResourceStore{}, &mocks.ModuleService{}, deadClock, defaultSyncBackoff, defaultMaxRetries)
 	assert.NotNil(t, s)
 }

--- a/core/read_test.go
+++ b/core/read_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -11,6 +12,11 @@ import (
 	"github.com/goto/entropy/core/mocks"
 	"github.com/goto/entropy/core/resource"
 	"github.com/goto/entropy/pkg/errors"
+)
+
+const (
+	defaultMaxRetries  = 5
+	defaultSyncBackoff = 5 * time.Second
 )
 
 func TestService_GetResource(t *testing.T) {
@@ -32,7 +38,7 @@ func TestService_GetResource(t *testing.T) {
 					GetByURN(mock.Anything, mock.Anything).
 					Return(nil, errors.ErrNotFound).
 					Once()
-				return core.New(repo, nil, nil)
+				return core.New(repo, nil, nil, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "foo:bar:baz",
 			wantErr: errors.ErrNotFound,
@@ -52,7 +58,7 @@ func TestService_GetResource(t *testing.T) {
 					Return(nil, nil).
 					Once()
 
-				return core.New(repo, mod, deadClock)
+				return core.New(repo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "foo:bar:baz",
 			want:    &sampleResource,
@@ -99,7 +105,7 @@ func TestService_ListResources(t *testing.T) {
 					List(mock.Anything, mock.Anything, false).
 					Return(nil, nil).
 					Once()
-				return core.New(repo, nil, deadClock)
+				return core.New(repo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			want:    nil,
 			wantErr: nil,
@@ -113,7 +119,7 @@ func TestService_ListResources(t *testing.T) {
 					List(mock.Anything, mock.Anything, false).
 					Return(nil, errStoreFailure).
 					Once()
-				return core.New(repo, nil, deadClock)
+				return core.New(repo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			want:    nil,
 			wantErr: errors.ErrInternal,
@@ -127,7 +133,7 @@ func TestService_ListResources(t *testing.T) {
 					List(mock.Anything, mock.Anything, false).
 					Return([]resource.Resource{sampleResource}, nil).
 					Once()
-				return core.New(repo, nil, deadClock)
+				return core.New(repo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			want:    []resource.Resource{sampleResource},
 			wantErr: nil,

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -37,7 +37,7 @@ func TestService_CreateResource(t *testing.T) {
 					PlanAction(mock.Anything, mock.Anything, mock.Anything).
 					Return(nil, errSample).Once()
 
-				return core.New(nil, mod, deadClock)
+				return core.New(nil, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -59,7 +59,7 @@ func TestService_CreateResource(t *testing.T) {
 					Return(nil, errors.ErrNotFound).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -98,7 +98,7 @@ func TestService_CreateResource(t *testing.T) {
 					}, nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -136,7 +136,7 @@ func TestService_CreateResource(t *testing.T) {
 					}, nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -170,7 +170,7 @@ func TestService_CreateResource(t *testing.T) {
 					Return(errSample).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -198,7 +198,7 @@ func TestService_CreateResource(t *testing.T) {
 					Create(mock.Anything, mock.Anything, mock.Anything).
 					Return(errors.ErrConflict).Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -255,7 +255,7 @@ func TestService_CreateResource(t *testing.T) {
 					}).
 					Return(nil)
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			res: resource.Resource{
 				Kind:    "mock",
@@ -328,7 +328,7 @@ func TestService_UpdateResource(t *testing.T) {
 					Return(nil, errors.ErrNotFound).
 					Once()
 
-				return core.New(resourceRepo, nil, deadClock)
+				return core.New(resourceRepo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn: "orn:entropy:mock:project:child",
 			update: resource.UpdateRequest{
@@ -357,7 +357,7 @@ func TestService_UpdateResource(t *testing.T) {
 					Return(&testResource, nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn: "orn:entropy:mock:project:child",
 			update: resource.UpdateRequest{
@@ -404,7 +404,7 @@ func TestService_UpdateResource(t *testing.T) {
 					Return(nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn: "orn:entropy:mock:project:child",
 			update: resource.UpdateRequest{
@@ -450,7 +450,7 @@ func TestService_UpdateResource(t *testing.T) {
 					}).
 					Twice()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn: "orn:entropy:mock:project:child",
 			update: resource.UpdateRequest{
@@ -513,7 +513,7 @@ func TestService_DeleteResource(t *testing.T) {
 					Return(nil, testErr).
 					Once()
 
-				return core.New(resourceRepo, nil, deadClock)
+				return core.New(resourceRepo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: testErr,
@@ -558,7 +558,7 @@ func TestService_DeleteResource(t *testing.T) {
 					Return(testErr).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: errors.ErrInternal,
@@ -603,7 +603,7 @@ func TestService_DeleteResource(t *testing.T) {
 					Return(nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: nil,
@@ -653,7 +653,7 @@ func TestService_ApplyAction(t *testing.T) {
 					Return(nil, errors.ErrNotFound).
 					Once()
 
-				return core.New(resourceRepo, nil, deadClock)
+				return core.New(resourceRepo, nil, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
@@ -680,7 +680,7 @@ func TestService_ApplyAction(t *testing.T) {
 					}, nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
@@ -713,7 +713,7 @@ func TestService_ApplyAction(t *testing.T) {
 					}, nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
@@ -756,7 +756,7 @@ func TestService_ApplyAction(t *testing.T) {
 					Return(nil).
 					Once()
 
-				return core.New(resourceRepo, mod, deadClock)
+				return core.New(resourceRepo, mod, deadClock, defaultSyncBackoff, defaultMaxRetries)
 			},
 			urn:    "orn:entropy:mock:foo:bar",
 			action: sampleAction,

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -125,6 +125,9 @@ type driverConf struct {
 
 	// delay between stopping a firehose and making an offset reset request
 	OffsetResetDelaySeconds int `json:"offset_reset_delay_seconds"`
+
+	// timeout value for a kube deployment run
+	KubeDeployTimeout int `json:"kube_deploy_timeout_seconds"`
 }
 
 type RequestsAndLimits struct {
@@ -293,6 +296,7 @@ func (fd *firehoseDriver) getHelmRelease(res resource.Resource, conf Config,
 	}
 
 	rc := helm.DefaultReleaseConfig()
+	rc.Timeout = fd.conf.KubeDeployTimeout
 	rc.Name = conf.DeploymentID
 	rc.Repository = chartRepo
 	rc.Chart = chartName

--- a/modules/firehose/driver_test.go
+++ b/modules/firehose/driver_test.go
@@ -82,7 +82,7 @@ func TestFirehoseDriver(t *testing.T) {
 				Chart:       "firehose",
 				Version:     "0.1.13",
 				Namespace:   "namespace-1",
-				Timeout:     300,
+				Timeout:     60,
 				Wait:        true,
 				ForceUpdate: true,
 				Values: map[string]any{
@@ -259,7 +259,7 @@ func TestFirehoseDriver(t *testing.T) {
 				Chart:       "firehose",
 				Version:     "0.1.13",
 				Namespace:   "namespace-1",
-				Timeout:     300,
+				Timeout:     60,
 				Wait:        true,
 				ForceUpdate: true,
 				Values: map[string]any{
@@ -444,7 +444,7 @@ func TestFirehoseDriver(t *testing.T) {
 				Chart:       "firehose",
 				Version:     "0.1.13",
 				Namespace:   "namespace-1",
-				Timeout:     300,
+				Timeout:     60,
 				Wait:        true,
 				ForceUpdate: true,
 				Values: map[string]any{
@@ -596,6 +596,7 @@ func TestFirehoseDriver(t *testing.T) {
 
 func firehoseDriverConf() driverConf {
 	return driverConf{
+		KubeDeployTimeout: 60,
 		NodeAffinityMatchExpressions: NodeAffinityMatchExpressions{
 			RequiredDuringSchedulingIgnoredDuringExecution: []Preference{
 				{


### PR DESCRIPTION
make the following configurable - kube deployment timeout, extendInterval, refreshInterval, defaultSyncBackoff, defaultMaxRetries, syncInterval