### PR TITLE
feat: modular worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: tidy
 
 e2e-test: tidy
 	@echo "Running e2e-test tests..."
-	@go test -v ./test/e2e_test/...
+	@go test -v ./test/e2e_test/... -timeout 20m
 
 test-coverage: test
 	@echo "Generating coverage report..."

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -23,6 +23,7 @@ func Execute(ctx context.Context) {
 		cmdConfig(),
 		cmdResourceCommand(),
 		cmdModuleCommand(),
+		cmdWorker(),
 	)
 
 	cmdx.SetHelp(rootCmd)

--- a/cli/config.go
+++ b/cli/config.go
@@ -35,10 +35,10 @@ type SyncerConf struct {
 	ExtendLockBy        time.Duration  `mapstructure:"extend_lock_by" default:"5s"`
 	SyncBackoffInterval time.Duration  `mapstructure:"sync_backoff_interval" default:"5s"`
 	MaxRetries          int            `mapstructure:"max_retries" default:"5"`
-	WorkerModules       []workerModule `mapstructure:"worker_modules"`
+	Workers             []workerConfig `mapstructure:"workers"`
 }
 
-type workerModule struct {
+type workerConfig struct {
 	Name  string              `mapstructure:"name"`
 	Count int                 `mapstructure:"count" default:"1"`
 	Scope map[string][]string `mapstructure:"labels"`

--- a/cli/config.go
+++ b/cli/config.go
@@ -35,10 +35,10 @@ type SyncerConf struct {
 	ExtendLockBy        time.Duration  `mapstructure:"extend_lock_by" default:"5s"`
 	SyncBackoffInterval time.Duration  `mapstructure:"sync_backoff_interval" default:"5s"`
 	MaxRetries          int            `mapstructure:"max_retries" default:"5"`
-	Workers             []workerConfig `mapstructure:"workers"`
+	Workers             []WorkerConfig `mapstructure:"workers"`
 }
 
-type workerConfig struct {
+type WorkerConfig struct {
 	Name  string              `mapstructure:"name"`
 	Count int                 `mapstructure:"count" default:"1"`
 	Scope map[string][]string `mapstructure:"labels"`

--- a/cli/config.go
+++ b/cli/config.go
@@ -30,11 +30,18 @@ type Config struct {
 }
 
 type SyncerConf struct {
-	SyncInterval        time.Duration `mapstructure:"sync_interval" default:"1s"`
-	RefreshInterval     time.Duration `mapstructure:"refresh_interval" default:"3s"`
-	ExtendLockBy        time.Duration `mapstructure:"extend_lock_by" default:"5s"`
-	SyncBackoffInterval time.Duration `mapstructure:"sync_backoff_interval" default:"5s"`
-	MaxRetries          int           `mapstructure:"max_retries" default:"5"`
+	SyncInterval        time.Duration  `mapstructure:"sync_interval" default:"1s"`
+	RefreshInterval     time.Duration  `mapstructure:"refresh_interval" default:"3s"`
+	ExtendLockBy        time.Duration  `mapstructure:"extend_lock_by" default:"5s"`
+	SyncBackoffInterval time.Duration  `mapstructure:"sync_backoff_interval" default:"5s"`
+	MaxRetries          int            `mapstructure:"max_retries" default:"5"`
+	WorkerModules       []workerModule `mapstructure:"worker_modules"`
+}
+
+type workerModule struct {
+	Name  string              `mapstructure:"name"`
+	Count int                 `mapstructure:"count" default:"1"`
+	Scope map[string][]string `mapstructure:"labels"`
 }
 
 type ServeConfig struct {

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
@@ -69,9 +68,8 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 		}
 	}
 
-	var wg *sync.WaitGroup
 	if spawnWorker {
-		wg = spawnWorkers(ctx, resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
+		wg := spawnWorkers(ctx, resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
 		defer func() {
 			wg.Wait()
 			zap.L().Info("all syncer workers exited")

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -71,8 +71,8 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 
 	var wg *sync.WaitGroup
 	if spawnWorker {
-		go func() {
-			wg = spawnWorkers(ctx, resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
+		wg = spawnWorkers(ctx, resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
+		defer func() {
 			wg.Wait()
 			zap.L().Info("all syncer workers exited")
 		}()

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/goto/entropy/core"
+	"github.com/goto/entropy/core/module"
+	"github.com/goto/entropy/pkg/logger"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func cmdWorker() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "worker",
+		Short: "Start workers",
+		Example: heredoc.Doc(`
+			$ entropy worker
+		`),
+		Annotations: map[string]string{
+			"group:other": "server",
+		},
+	}
+
+	cmd.RunE = handleErr(func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfig(cmd)
+		if err != nil {
+			return err
+		}
+
+		err = logger.Setup(&cfg.Log)
+		if err != nil {
+			return err
+		}
+
+		store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
+		moduleService := module.NewService(setupRegistry(), store)
+		resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
+
+		var wg *sync.WaitGroup
+		go func() {
+			wg = spawnWorkers(cmd.Context(), resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
+		}()
+
+		quitChannel := make(chan os.Signal, 1)
+		signal.Notify(quitChannel, syscall.SIGINT, syscall.SIGTERM)
+		<-quitChannel
+
+		wg.Wait()
+		zap.L().Info("all syncer workers exited")
+
+		return nil
+	})
+
+	return cmd
+}
+
+func spawnWorkers(ctx context.Context, resourceService *core.Service, workerModules []workerModule, syncInterval time.Duration) (wg *sync.WaitGroup) {
+	if len(workerModules) == 0 {
+		wg = resourceService.RunSyncer(ctx, 1, syncInterval, map[string][]string{})
+	} else {
+		for _, module := range workerModules {
+			wg = resourceService.RunSyncer(ctx, module.Count, syncInterval, module.Scope)
+		}
+	}
+	return
+}

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -41,10 +41,8 @@ func cmdWorker() *cobra.Command {
 		resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
 
 		wg := spawnWorkers(cmd.Context(), resourceService, cfg.Syncer.WorkerModules, cfg.Syncer.SyncInterval)
-		defer func() {
-			wg.Wait()
-			zap.L().Info("all syncer workers exited")
-		}()
+		wg.Wait()
+		zap.L().Info("all syncer workers exited")
 
 		return nil
 	})
@@ -56,10 +54,10 @@ func spawnWorkers(ctx context.Context, resourceService *core.Service, workerModu
 	wg := &sync.WaitGroup{}
 
 	if len(workerModules) == 0 {
-		wg = resourceService.RunSyncer(ctx, 1, syncInterval, map[string][]string{}, wg)
+		resourceService.RunSyncer(ctx, 1, syncInterval, map[string][]string{}, wg)
 	} else {
 		for _, module := range workerModules {
-			wg = resourceService.RunSyncer(ctx, module.Count, syncInterval, module.Scope, wg)
+			resourceService.RunSyncer(ctx, module.Count, syncInterval, module.Scope, wg)
 		}
 	}
 	return wg

--- a/core/mocks/resource_store.go
+++ b/core/mocks/resource_store.go
@@ -324,17 +324,17 @@ func (_c *ResourceStore_Revisions_Call) RunAndReturn(run func(context.Context, r
 	return _c
 }
 
-// SyncOne provides a mock function with given fields: ctx, syncFn
-func (_m *ResourceStore) SyncOne(ctx context.Context, syncFn resource.SyncFn) error {
-	ret := _m.Called(ctx, syncFn)
+// SyncOne provides a mock function with given fields: ctx, scope, syncFn
+func (_m *ResourceStore) SyncOne(ctx context.Context, scope map[string][]string, syncFn resource.SyncFn) error {
+	ret := _m.Called(ctx, scope, syncFn)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SyncOne")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, resource.SyncFn) error); ok {
-		r0 = rf(ctx, syncFn)
+	if rf, ok := ret.Get(0).(func(context.Context, map[string][]string, resource.SyncFn) error); ok {
+		r0 = rf(ctx, scope, syncFn)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -349,14 +349,15 @@ type ResourceStore_SyncOne_Call struct {
 
 // SyncOne is a helper method to define mock.On call
 //   - ctx context.Context
+//   - scope map[string][]string
 //   - syncFn resource.SyncFn
-func (_e *ResourceStore_Expecter) SyncOne(ctx interface{}, syncFn interface{}) *ResourceStore_SyncOne_Call {
-	return &ResourceStore_SyncOne_Call{Call: _e.mock.On("SyncOne", ctx, syncFn)}
+func (_e *ResourceStore_Expecter) SyncOne(ctx interface{}, scope interface{}, syncFn interface{}) *ResourceStore_SyncOne_Call {
+	return &ResourceStore_SyncOne_Call{Call: _e.mock.On("SyncOne", ctx, scope, syncFn)}
 }
 
-func (_c *ResourceStore_SyncOne_Call) Run(run func(ctx context.Context, syncFn resource.SyncFn)) *ResourceStore_SyncOne_Call {
+func (_c *ResourceStore_SyncOne_Call) Run(run func(ctx context.Context, scope map[string][]string, syncFn resource.SyncFn)) *ResourceStore_SyncOne_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(resource.SyncFn))
+		run(args[0].(context.Context), args[1].(map[string][]string), args[2].(resource.SyncFn))
 	})
 	return _c
 }
@@ -366,7 +367,7 @@ func (_c *ResourceStore_SyncOne_Call) Return(_a0 error) *ResourceStore_SyncOne_C
 	return _c
 }
 
-func (_c *ResourceStore_SyncOne_Call) RunAndReturn(run func(context.Context, resource.SyncFn) error) *ResourceStore_SyncOne_Call {
+func (_c *ResourceStore_SyncOne_Call) RunAndReturn(run func(context.Context, map[string][]string, resource.SyncFn) error) *ResourceStore_SyncOne_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -27,7 +27,7 @@ type Store interface {
 
 	Revisions(ctx context.Context, selector RevisionsSelector) ([]Revision, error)
 
-	SyncOne(ctx context.Context, syncFn SyncFn) error
+	SyncOne(ctx context.Context, scope map[string][]string, syncFn SyncFn) error
 }
 
 type SyncFn func(ctx context.Context, res Resource) (*Resource, error)

--- a/core/sync.go
+++ b/core/sync.go
@@ -13,7 +13,7 @@ import (
 
 // RunSyncer runs the syncer thread that keeps performing resource-sync at
 // regular intervals.
-func (svc *Service) RunSyncer(ctx context.Context, workerCount int, interval time.Duration, scope map[string][]string, wg *sync.WaitGroup) *sync.WaitGroup {
+func (svc *Service) RunSyncer(ctx context.Context, workerCount int, interval time.Duration, scope map[string][]string, wg *sync.WaitGroup) {
 	for i := 0; i < workerCount; i++ {
 		wg.Add(1)
 		go func(id int) {
@@ -38,8 +38,6 @@ func (svc *Service) RunSyncer(ctx context.Context, workerCount int, interval tim
 			}
 		}(i)
 	}
-
-	return wg
 }
 
 func (svc *Service) handleSync(ctx context.Context, res resource.Resource) (*resource.Resource, error) {

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.1 // indirect
+	github.com/google/uuid v1.3.1
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
@@ -171,7 +171,7 @@ require (
 	golang.org/x/crypto v0.20.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.13.0
-	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/sync v0.4.0
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	gorillamux "github.com/gorilla/mux"
-	"github.com/goto/salt/mux"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpcrecovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -29,6 +28,7 @@ import (
 	"github.com/goto/entropy/pkg/version"
 	commonv1 "github.com/goto/entropy/proto/gotocompany/common/v1"
 	entropyv1beta1 "github.com/goto/entropy/proto/gotocompany/entropy/v1beta1"
+	"github.com/goto/salt/mux"
 )
 
 const (

--- a/internal/store/postgres/postgres_test.go
+++ b/internal/store/postgres/postgres_test.go
@@ -1,0 +1,54 @@
+package postgres_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/goto/entropy/core/resource"
+	"github.com/goto/entropy/internal/store/postgres"
+	"github.com/goto/salt/dockertestx"
+	"github.com/ory/dockertest/v3"
+)
+
+func newTestClient(t *testing.T) (*postgres.Store, *dockertest.Pool, *dockertest.Resource) {
+	t.Helper()
+
+	pgDocker, err := dockertestx.CreatePostgres(dockertestx.PostgresWithDockertestResourceExpiry(120))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := postgres.Open(pgDocker.GetExternalConnString(), 3*time.Second, 5*time.Second, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Migrate(context.TODO()); err != nil {
+		t.Fatal(err)
+	}
+
+	return store, pgDocker.GetPool(), pgDocker.GetResource()
+}
+
+func bootstrapResources(ctx context.Context, store *postgres.Store) ([]resource.Resource, error) {
+	testFixtureJSON, err := os.ReadFile("./testdata/resources.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var data []resource.Resource
+	if err = json.Unmarshal(testFixtureJSON, &data); err != nil {
+		return nil, err
+	}
+
+	for _, d := range data {
+		if err := store.Create(ctx, d); err != nil {
+			return nil, err
+		}
+	}
+
+	return data, nil
+}

--- a/internal/store/postgres/resource_store_test.go
+++ b/internal/store/postgres/resource_store_test.go
@@ -1,0 +1,119 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goto/entropy/core/resource"
+	"github.com/goto/entropy/internal/store/postgres"
+	"github.com/goto/entropy/pkg/errors"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResourceStoreTestSuite struct {
+	suite.Suite
+	ctx       context.Context
+	pool      *dockertest.Pool
+	resource  *dockertest.Resource
+	store     *postgres.Store
+	resources []resource.Resource
+}
+
+func (s *ResourceStoreTestSuite) SetupTest() {
+	s.store, s.pool, s.resource = newTestClient(s.T())
+	s.ctx = context.Background()
+
+	var err error
+	s.resources, err = bootstrapResources(s.ctx, s.store)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
+	s.Assert().Equal(len(s.resources), 6)
+}
+
+func (s *ResourceStoreTestSuite) TestSyncOne() {
+	type testCase struct {
+		Description string
+		Scope       map[string][]string
+		syncFn      resource.SyncFn
+		ErrString   string
+	}
+
+	projectScope := []string{"test-project-00"}
+	kindScope := []string{"dagger"}
+	unknownScope := []string{"unknown"}
+
+	testCases := []testCase{
+		{
+			Description: "if scope is empty, it will take any job",
+			Scope:       map[string][]string{},
+			syncFn: func(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
+				if res.URN == "" {
+					return nil, errors.New("no empty resource")
+				}
+				return &res, nil
+			},
+		},
+		{
+			Description: "take job with project test-project-00",
+			Scope: map[string][]string{
+				"project": projectScope,
+			},
+			syncFn: func(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
+				if res.Project != "test-project-00" {
+					return nil, errors.New("wrong resource project")
+				}
+				return &res, nil
+			},
+		},
+		{
+			Description: "take job with kind dagger",
+			Scope: map[string][]string{
+				"kind": kindScope,
+			},
+			syncFn: func(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
+				if res.Kind != "dagger" {
+					return nil, errors.New("wrong resource kind")
+				}
+				return &res, nil
+			},
+		},
+		{
+			Description: "throw error for unknown field",
+			Scope: map[string][]string{
+				"unknown": unknownScope,
+			},
+			syncFn: func(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
+				return &res, nil
+			},
+			ErrString: "pq: column \"unknown\" does not exist",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.Description, func() {
+			err := s.store.SyncOne(s.ctx, tc.Scope, tc.syncFn)
+			if tc.ErrString != "" {
+				if err.Error() != tc.ErrString {
+					s.T().Fatalf("got error %s, expected was %s", err.Error(), tc.ErrString)
+				}
+			} else {
+				if err != nil {
+					s.T().Fatalf("got error %s, expected was none", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func (s *ResourceStoreTestSuite) TearDownTest() {
+	if err := s.pool.Purge(s.resource); err != nil {
+		s.T().Fatal(err)
+	}
+}
+
+func TestResourceStore(t *testing.T) {
+	suite.Run(t, new(ResourceStoreTestSuite))
+}

--- a/internal/store/postgres/testdata/resources.json
+++ b/internal/store/postgres/testdata/resources.json
@@ -1,0 +1,74 @@
+[
+    {
+        "urn": "orn:entropy:firehose:test-project-00:test-firehose",
+        "kind": "firehose",
+        "name": "test-firehose",
+        "project": "test-project-00",
+        "labels": {
+            "description": "test firehose resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "urn": "orn:entropy:dagger:test-project-01:test-dagger",
+        "kind": "dagger",
+        "name": "test-dagger",
+        "project": "test-project-01",
+        "labels": {
+            "description": "test dagger resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "urn": "orn:entropy:firehose:test-project-01:test-firehose-01",
+        "kind": "firehose",
+        "name": "test-firehose",
+        "project": "test-project-01",
+        "labels": {
+            "description": "test firehose resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "urn": "orn:entropy:dagger:test-project-00:test-dagger-01",
+        "kind": "dagger",
+        "name": "test-dagger",
+        "project": "test-project-00",
+        "labels": {
+            "description": "test dagger resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "urn": "orn:entropy:firehose:test-project-00:test-firehose-02",
+        "kind": "firehose",
+        "name": "test-firehose",
+        "project": "test-project-00",
+        "labels": {
+            "description": "test firehose resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    },
+    {
+        "urn": "orn:entropy:dagger:test-project-01:test-dagger-02",
+        "kind": "dagger",
+        "name": "test-dagger",
+        "project": "test-project-01",
+        "labels": {
+            "description": "test dagger resource"
+        },
+        "state": {
+            "next_sync_at": "0001-01-01T00:00:00Z"
+        }
+    }
+]

--- a/test/e2e_test/firehose_helper_test.go
+++ b/test/e2e_test/firehose_helper_test.go
@@ -2,9 +2,12 @@ package e2e_test
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"time"
 
 	"github.com/goto/entropy/pkg/kube"
+	entropyv1beta1 "github.com/goto/entropy/proto/gotocompany/entropy/v1beta1"
 	"github.com/goto/entropy/test/testbench"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -35,4 +38,19 @@ func getRunningFirehosePods(ctx context.Context, kubeProvider *cluster.Provider,
 	}
 
 	return pods, nil
+}
+
+func getFirehoseResourceRequest() (*entropyv1beta1.Resource, error) {
+	resourceData, err := os.ReadFile(testbench.TestDataPath + "/resource/firehose_resource.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var resourceConfig *entropyv1beta1.Resource
+	err = json.Unmarshal(resourceData, &resourceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceConfig, nil
 }

--- a/test/e2e_test/worker_test.go
+++ b/test/e2e_test/worker_test.go
@@ -100,7 +100,7 @@ func (s *WorkerTestSuite) TestWorkerDefault() {
 }
 
 func (s *WorkerTestSuite) TestWorkerScope() {
-	projectScope := []string{"test-project-0"}
+	projectScope := []string{s.resources[0].Project}
 	workerConfig := cli.WorkerConfig{
 		Name:  "test-project-0-worker",
 		Count: 1,
@@ -115,6 +115,14 @@ func (s *WorkerTestSuite) TestWorkerScope() {
 	s.Run("running worker with project scoped config will run worker(s) that takes configured project job", func() {
 		resourceConfig, err := getFirehoseResourceRequest()
 		s.Require().NoError(err)
+
+		resourceConfig.Project = s.resources[0].Project
+		resourceConfig.Spec.Dependencies = []*entropyv1beta1.ResourceDependency{
+			{
+				Key:   "kube_cluster",
+				Value: s.resources[0].Urn,
+			},
+		}
 
 		resp, err := s.resourceClient.CreateResource(s.ctx, &entropyv1beta1.CreateResourceRequest{
 			Resource: resourceConfig,

--- a/test/e2e_test/worker_test.go
+++ b/test/e2e_test/worker_test.go
@@ -1,0 +1,180 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goto/entropy/cli"
+	"github.com/goto/entropy/core/resource"
+	entropyv1beta1 "github.com/goto/entropy/proto/gotocompany/entropy/v1beta1"
+	"github.com/goto/entropy/test/testbench"
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/kind/pkg/cluster"
+)
+
+type WorkerTestSuite struct {
+	suite.Suite
+	ctx                  context.Context
+	moduleClient         entropyv1beta1.ModuleServiceClient
+	resourceClient       entropyv1beta1.ResourceServiceClient
+	cancelResourceClient func()
+	cancelModuleClient   func()
+	cancel               func()
+	appConfig            *cli.Config
+	pool                 *dockertest.Pool
+	resource             *dockertest.Resource
+	kubeProvider         *cluster.Provider
+	resources            []*entropyv1beta1.Resource
+}
+
+func (s *WorkerTestSuite) SetupTest() {
+	s.ctx, s.moduleClient, s.resourceClient, s.appConfig, s.pool, s.resource, s.kubeProvider, s.cancelModuleClient, s.cancelResourceClient, s.cancel = testbench.SetupTests(s.T(), false)
+
+	modules, err := s.moduleClient.ListModules(s.ctx, &entropyv1beta1.ListModulesRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(6, len(modules.GetModules()))
+
+	resources, err := s.resourceClient.ListResources(s.ctx, &entropyv1beta1.ListResourcesRequest{
+		Kind: "kubernetes",
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(3, len(resources.GetResources()))
+	s.resources = resources.GetResources()
+
+}
+
+func (s *WorkerTestSuite) TestWorkerDefault() {
+	testbench.SetupWorker(s.T(), s.ctx, *s.appConfig)
+
+	s.Run("running worker with default config will run one worker that takes any job", func() {
+		resourceConfig, err := getFirehoseResourceRequest()
+		s.Require().NoError(err)
+
+		resp, err := s.resourceClient.CreateResource(s.ctx, &entropyv1beta1.CreateResourceRequest{
+			Resource: resourceConfig,
+		})
+		s.Require().NoError(err)
+
+		pods, err := getRunningFirehosePods(s.ctx, s.kubeProvider, testbench.TestClusterName, testbench.TestNamespace, map[string]string{}, 90*time.Second)
+		s.Require().NoError(err)
+		s.Require().Equal(1, len(pods))
+
+		createdFirehose, err := s.resourceClient.GetResource(s.ctx, &entropyv1beta1.GetResourceRequest{
+			Urn: resp.GetResource().Urn,
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(createdFirehose)
+		s.Require().Equal(resource.StatusCompleted, createdFirehose.Resource.State.Status.String())
+	})
+
+	s.Run("running worker with default config will run one worker that takes any job", func() {
+		resourceConfig, err := getFirehoseResourceRequest()
+		s.Require().NoError(err)
+
+		resourceConfig.Project = s.resources[1].Project
+		resourceConfig.Spec.Dependencies = []*entropyv1beta1.ResourceDependency{
+			{
+				Key:   "kube_cluster",
+				Value: s.resources[1].Urn,
+			},
+		}
+
+		resp, err := s.resourceClient.CreateResource(s.ctx, &entropyv1beta1.CreateResourceRequest{
+			Resource: resourceConfig,
+		})
+		s.Require().NoError(err)
+
+		pods, err := getRunningFirehosePods(s.ctx, s.kubeProvider, testbench.TestClusterName, testbench.TestNamespace, map[string]string{}, 90*time.Second)
+		s.Require().NoError(err)
+		s.Require().Equal(2, len(pods))
+
+		createdFirehose, err := s.resourceClient.GetResource(s.ctx, &entropyv1beta1.GetResourceRequest{
+			Urn: resp.GetResource().Urn,
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(createdFirehose)
+		s.Require().Equal(resource.StatusCompleted, createdFirehose.Resource.State.Status.String())
+	})
+}
+
+func (s *WorkerTestSuite) TestWorkerScope() {
+	projectScope := []string{"test-project-0"}
+	workerConfig := cli.WorkerConfig{
+		Name:  "test-project-0-worker",
+		Count: 1,
+		Scope: map[string][]string{
+			"project": projectScope,
+		},
+	}
+
+	s.appConfig.Syncer.Workers = []cli.WorkerConfig{workerConfig}
+	testbench.SetupWorker(s.T(), s.ctx, *s.appConfig)
+
+	s.Run("running worker with project scoped config will run worker(s) that takes configured project job", func() {
+		resourceConfig, err := getFirehoseResourceRequest()
+		s.Require().NoError(err)
+
+		resp, err := s.resourceClient.CreateResource(s.ctx, &entropyv1beta1.CreateResourceRequest{
+			Resource: resourceConfig,
+		})
+		s.Require().NoError(err)
+
+		pods, err := getRunningFirehosePods(s.ctx, s.kubeProvider, testbench.TestClusterName, testbench.TestNamespace, map[string]string{}, 90*time.Second)
+		s.Require().NoError(err)
+		s.Require().Equal(1, len(pods))
+
+		createdFirehose, err := s.resourceClient.GetResource(s.ctx, &entropyv1beta1.GetResourceRequest{
+			Urn: resp.GetResource().Urn,
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(createdFirehose)
+		s.Require().Equal(resource.StatusCompleted, createdFirehose.Resource.State.Status.String())
+	})
+
+	s.Run("running worker with project scoped config will run worker(s) that won't takes none configured project job", func() {
+		resourceConfig, err := getFirehoseResourceRequest()
+		s.Require().NoError(err)
+
+		resourceConfig.Project = s.resources[1].Project
+		resourceConfig.Spec.Dependencies = []*entropyv1beta1.ResourceDependency{
+			{
+				Key:   "kube_cluster",
+				Value: s.resources[1].Urn,
+			},
+		}
+
+		resp, err := s.resourceClient.CreateResource(s.ctx, &entropyv1beta1.CreateResourceRequest{
+			Resource: resourceConfig,
+		})
+		s.Require().NoError(err)
+
+		pods, err := getRunningFirehosePods(s.ctx, s.kubeProvider, testbench.TestClusterName, testbench.TestNamespace, map[string]string{}, 90*time.Second)
+		s.Require().NoError(err)
+		s.Require().Equal(1, len(pods))
+
+		createdFirehose, err := s.resourceClient.GetResource(s.ctx, &entropyv1beta1.GetResourceRequest{
+			Urn: resp.GetResource().Urn,
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(createdFirehose)
+		s.Require().Equal(resource.StatusPending, createdFirehose.Resource.State.Status.String())
+	})
+}
+
+func (s *WorkerTestSuite) TearDownTest() {
+	if err := s.pool.Purge(s.resource); err != nil {
+		s.T().Fatal(err)
+	}
+
+	if err := s.kubeProvider.Delete(testbench.TestClusterName, ""); err != nil {
+		s.T().Fatal(err)
+	}
+
+	s.cancel()
+}
+
+func TestWorkerTestSuite(t *testing.T) {
+	suite.Run(t, new(WorkerTestSuite))
+}

--- a/test/testbench/bootstrap.go
+++ b/test/testbench/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
 	entropyv1beta1 "github.com/goto/entropy/proto/gotocompany/entropy/v1beta1"
@@ -21,10 +22,14 @@ func BootstrapKubernetesModule(ctx context.Context, client entropyv1beta1.Module
 		return err
 	}
 
-	if _, err := client.CreateModule(ctx, &entropyv1beta1.CreateModuleRequest{
-		Module: moduleConfig,
-	}); err != nil {
-		return err
+	project := moduleConfig.Project
+	for i := 0; i < 3; i++ {
+		moduleConfig.Project = fmt.Sprintf("%s-%d", project, i)
+		if _, err := client.CreateModule(ctx, &entropyv1beta1.CreateModuleRequest{
+			Module: moduleConfig,
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -41,11 +46,17 @@ func BootstrapFirehoseModule(ctx context.Context, client entropyv1beta1.ModuleSe
 		return err
 	}
 
-	if _, err := client.CreateModule(ctx, &entropyv1beta1.CreateModuleRequest{
-		Module: moduleConfig,
-	}); err != nil {
-		return err
+	project := moduleConfig.Project
+	for i := 0; i < 3; i++ {
+		moduleConfig.Project = fmt.Sprintf("%s-%d", project, i)
+
+		if _, err := client.CreateModule(ctx, &entropyv1beta1.CreateModuleRequest{
+			Module: moduleConfig,
+		}); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 
@@ -102,10 +113,15 @@ func BootstrapKubernetesResource(ctx context.Context, client entropyv1beta1.Reso
 		return err
 	}
 
-	if _, err := client.CreateResource(ctx, &entropyv1beta1.CreateResourceRequest{
-		Resource: resourceConfig,
-	}); err != nil {
-		return errors.New(resourceConfig.Spec.Configs.GetStringValue())
+	project := resourceConfig.Project
+	for i := 0; i < 3; i++ {
+		resourceConfig.Project = fmt.Sprintf("%s-%d", project, i)
+
+		if _, err := client.CreateResource(ctx, &entropyv1beta1.CreateResourceRequest{
+			Resource: resourceConfig,
+		}); err != nil {
+			return errors.New(resourceConfig.Spec.Configs.GetStringValue())
+		}
 	}
 
 	return nil

--- a/test/testbench/test_data/resource/firehose_resource.json
+++ b/test/testbench/test_data/resource/firehose_resource.json
@@ -1,7 +1,7 @@
 {
     "kind": "firehose",
     "name": "test-firehose",
-    "project": "test-project",
+    "project": "test-project-0",
     "labels": {
         "description": "test firehose resource"
     },
@@ -22,7 +22,7 @@
         "dependencies": [
             {
                 "key": "kube_cluster",
-                "value": "orn:entropy:kubernetes:test-project:test-kube"
+                "value": "orn:entropy:kubernetes:test-project-0:test-kube"
             }
         ]
     }


### PR DESCRIPTION
Enable creation of modular worker in entropy. Including:
- CLI Command to spawn worker `entropy worker` with given config
- Configurable worker, ex:
```yaml
syncer:
    worker_modules:
        - name: test-project-only
          count: 1
          labels:
              project: ['test-project']
        - name: firehose-only
          count: 1
          labels:
              kind: ['firehose']
        - name: default
          count: 1
```