### PR TITLE
 fix: change worker config to map

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -30,16 +30,15 @@ type Config struct {
 }
 
 type SyncerConf struct {
-	SyncInterval        time.Duration  `mapstructure:"sync_interval" default:"1s"`
-	RefreshInterval     time.Duration  `mapstructure:"refresh_interval" default:"3s"`
-	ExtendLockBy        time.Duration  `mapstructure:"extend_lock_by" default:"5s"`
-	SyncBackoffInterval time.Duration  `mapstructure:"sync_backoff_interval" default:"5s"`
-	MaxRetries          int            `mapstructure:"max_retries" default:"5"`
-	Workers             []WorkerConfig `mapstructure:"workers"`
+	SyncInterval        time.Duration           `mapstructure:"sync_interval" default:"1s"`
+	RefreshInterval     time.Duration           `mapstructure:"refresh_interval" default:"3s"`
+	ExtendLockBy        time.Duration           `mapstructure:"extend_lock_by" default:"5s"`
+	SyncBackoffInterval time.Duration           `mapstructure:"sync_backoff_interval" default:"5s"`
+	MaxRetries          int                     `mapstructure:"max_retries" default:"5"`
+	Workers             map[string]WorkerConfig `mapstructure:"workers" default:"[]"`
 }
 
 type WorkerConfig struct {
-	Name  string              `mapstructure:"name"`
 	Count int                 `mapstructure:"count" default:"1"`
 	Scope map[string][]string `mapstructure:"labels"`
 }

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -55,7 +55,7 @@ func StartWorkers(ctx context.Context, cfg Config) error {
 	return nil
 }
 
-func spawnWorkers(ctx context.Context, resourceService *core.Service, workerModules []WorkerConfig, syncInterval time.Duration, eg *errgroup.Group) {
+func spawnWorkers(ctx context.Context, resourceService *core.Service, workerModules map[string]WorkerConfig, syncInterval time.Duration, eg *errgroup.Group) {
 	if len(workerModules) == 0 {
 		resourceService.RunSyncer(ctx, 1, syncInterval, map[string][]string{}, eg)
 	} else {

--- a/test/e2e_test/worker_test.go
+++ b/test/e2e_test/worker_test.go
@@ -102,14 +102,13 @@ func (s *WorkerTestSuite) TestWorkerDefault() {
 func (s *WorkerTestSuite) TestWorkerScope() {
 	projectScope := []string{s.resources[0].Project}
 	workerConfig := cli.WorkerConfig{
-		Name:  "test-project-0-worker",
 		Count: 1,
 		Scope: map[string][]string{
 			"project": projectScope,
 		},
 	}
 
-	s.appConfig.Syncer.Workers = []cli.WorkerConfig{workerConfig}
+	s.appConfig.Syncer.Workers = map[string]cli.WorkerConfig{"test-project-0-worker": workerConfig}
 	testbench.SetupWorker(s.T(), s.ctx, *s.appConfig)
 
 	s.Run("running worker with project scoped config will run worker(s) that takes configured project job", func() {


### PR DESCRIPTION
Format worker config to:
```yaml
syncer:
  workers:
    firehose-only:
      count: 1
      labels:
        kind: ["firehose"]
    test-project-only:
      count: 1
      labels:
        project: ["test-project"]
```
or
``` bash
export SYNCER_WORKERS='{"test-project-only":{"count":1,"labels":{"project":["test-project-only"]}},"firehose-only":{"count":1,"labels":{"kind":["firehose"]}}}'
```