### PR TITLE
feat: add masking to list resources

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -22,11 +22,12 @@ const configFlag = "config"
 
 // Config contains the application configuration.
 type Config struct {
-	Log       logger.LogConfig `mapstructure:"log"`
-	Syncer    SyncerConf       `mapstructure:"syncer"`
-	Service   ServeConfig      `mapstructure:"service"`
-	PGConnStr string           `mapstructure:"pg_conn_str" default:"postgres://postgres@localhost:5432/entropy?sslmode=disable"`
-	Telemetry telemetry.Config `mapstructure:"telemetry"`
+	Log        logger.LogConfig `mapstructure:"log"`
+	Syncer     SyncerConf       `mapstructure:"syncer"`
+	Service    ServeConfig      `mapstructure:"service"`
+	PGConnStr  string           `mapstructure:"pg_conn_str" default:"postgres://postgres@localhost:5432/entropy?sslmode=disable"`
+	Telemetry  telemetry.Config `mapstructure:"telemetry"`
+	SecretMask string           `mapstructure:"secret_mask"`
 }
 
 type SyncerConf struct {

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -63,7 +63,7 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 	)
 
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
-	moduleService := module.NewService(setupRegistry(), store)
+	moduleService := module.NewService(setupRegistry(), store, cfg.SecretMask)
 	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
 
 	if migrate {

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -57,7 +57,7 @@ func cmdWorker() *cobra.Command {
 
 func StartWorkers(ctx context.Context, cfg Config) error {
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
-	moduleService := module.NewService(setupRegistry(), store)
+	moduleService := module.NewService(setupRegistry(), store, cfg.SecretMask)
 	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
 
 	eg := &errgroup.Group{}

--- a/core/core.go
+++ b/core/core.go
@@ -18,6 +18,7 @@ type Service struct {
 	moduleSvc      ModuleService
 	syncBackoff    time.Duration
 	maxSyncRetries int
+	secretMask     string
 }
 
 type ModuleService interface {
@@ -25,6 +26,7 @@ type ModuleService interface {
 	SyncState(ctx context.Context, res module.ExpandedResource) (*resource.State, error)
 	StreamLogs(ctx context.Context, res module.ExpandedResource, filter map[string]string) (<-chan module.LogChunk, error)
 	GetOutput(ctx context.Context, res module.ExpandedResource) (json.RawMessage, error)
+	MaskSecrets(ctx context.Context, res resource.Resource) (resource.Resource, error)
 }
 
 func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time, syncBackoffInterval time.Duration, maxRetries int) *Service {

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -29,6 +29,7 @@ type Descriptor struct {
 	Actions       []ActionDesc                               `json:"actions"`
 	Dependencies  map[string]string                          `json:"dependencies"`
 	DriverFactory func(conf json.RawMessage) (Driver, error) `json:"-"`
+	Secrets       []string                                   `json:"secrets"`
 }
 
 // Registry is responsible for installing and managing module-drivers as per

--- a/core/read.go
+++ b/core/read.go
@@ -36,6 +36,11 @@ func (svc *Service) GetResource(ctx context.Context, urn string) (*resource.Reso
 		}
 	}
 
+	*res, err = svc.moduleSvc.MaskSecrets(ctx, *res)
+	if err != nil {
+		return nil, err
+	}
+
 	return res, nil
 }
 

--- a/core/read_test.go
+++ b/core/read_test.go
@@ -17,6 +17,7 @@ import (
 const (
 	defaultMaxRetries  = 5
 	defaultSyncBackoff = 5 * time.Second
+	secretMask         = "[MASKED]"
 )
 
 func TestService_GetResource(t *testing.T) {

--- a/modules/registry.go
+++ b/modules/registry.go
@@ -2,7 +2,10 @@ package modules
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/goto/entropy/core/module"
@@ -53,6 +56,10 @@ func (mr *Registry) Register(desc module.Descriptor) error {
 		}
 		desc.Actions[i] = action
 	}
+
+	secretKey := fmt.Sprintf("%s_SECRET", strings.ToUpper(desc.Kind))
+	secrets := os.Getenv(secretKey)
+	desc.Secrets = strings.Split(secrets, ",")
 	mr.modules[desc.Kind] = desc
 	return nil
 }

--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -1,0 +1,17 @@
+package json
+
+import (
+	"encoding/json"
+
+	"github.com/tidwall/sjson"
+)
+
+func SetJSONField(json json.RawMessage, key string, value interface{}) (json.RawMessage, error) {
+	sjson, err := sjson.SetBytes(json, key, value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sjson, nil
+}


### PR DESCRIPTION
We are introducing secret masking feature in entropy.
List of secrets can be defined as environment varibale for each module kind as follows:

```
FIREHOSE_SECRET : SINK_REDIS_AUTH_PASSWORD,big_query_sink_credential,dlq_gcs_sink_credential
```

The secret can be in resource config as well as resource output.
We should be able to configure nested secret as `rootfield.nest1.nest2`

On Get and List resource these fields should be nested.
On updated, if user passes value for these fields as masked value, entropy should use the previous value in the resource.
