### PR TITLE
feat: add metrics for res status change

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -64,7 +64,7 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
 	moduleService := module.NewService(setupRegistry(), store)
-	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
+	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries, cfg.Telemetry.ServiceName)
 
 	if migrate {
 		if migrateErr := runMigrations(ctx, cfg); migrateErr != nil {

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -58,7 +58,7 @@ func cmdWorker() *cobra.Command {
 func StartWorkers(ctx context.Context, cfg Config) error {
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
 	moduleService := module.NewService(setupRegistry(), store)
-	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries)
+	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries, cfg.Telemetry.ServiceName)
 
 	eg := &errgroup.Group{}
 	spawnWorkers(ctx, resourceService, cfg.Syncer.Workers, cfg.Syncer.SyncInterval, eg)

--- a/core/core.go
+++ b/core/core.go
@@ -18,6 +18,7 @@ type Service struct {
 	moduleSvc      ModuleService
 	syncBackoff    time.Duration
 	maxSyncRetries int
+	serviceName    string
 }
 
 type ModuleService interface {
@@ -27,7 +28,7 @@ type ModuleService interface {
 	GetOutput(ctx context.Context, res module.ExpandedResource) (json.RawMessage, error)
 }
 
-func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time, syncBackoffInterval time.Duration, maxRetries int) *Service {
+func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time, syncBackoffInterval time.Duration, maxRetries int, serviceName string) *Service {
 	if clockFn == nil {
 		clockFn = time.Now
 	}
@@ -38,6 +39,7 @@ func New(repo resource.Store, moduleSvc ModuleService, clockFn func() time.Time,
 		syncBackoff:    syncBackoffInterval,
 		maxSyncRetries: maxRetries,
 		moduleSvc:      moduleSvc,
+		serviceName:    serviceName,
 	}
 }
 

--- a/core/write.go
+++ b/core/write.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goto/entropy/core/module"
 	"github.com/goto/entropy/core/resource"
 	"github.com/goto/entropy/pkg/errors"
+	"github.com/goto/entropy/pkg/telemetry"
 )
 
 type Options struct {
@@ -101,6 +102,16 @@ func (svc *Service) execAction(ctx context.Context, res resource.Resource, act m
 			return nil, err
 		}
 	}
+
+	meter := telemetry.GetMeter(svc.serviceName)
+	pendingCounter, err := setupCounter(meter, PendingCounter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Increment the pending counter.
+	pendingCounter.Add(context.Background(), 1)
+
 	return planned, nil
 }
 

--- a/pkg/telemetry/opentelemetry.go
+++ b/pkg/telemetry/opentelemetry.go
@@ -1,0 +1,124 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+)
+
+func setupOpenTelemetry(ctx context.Context, mux *http.ServeMux, cfg Config) error {
+	// Create resource with service information
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Setup metrics if enabled
+	if cfg.EnableMetrics {
+		if err := setupMetrics(ctx, cfg, res, mux); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setupMetrics(ctx context.Context, cfg Config, res *resource.Resource, mux *http.ServeMux) error {
+	promExporter, err := prometheus.New(prometheus.WithNamespace(cfg.ServiceName))
+	if err != nil {
+		return err
+	}
+
+	otlpExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithInsecure(),
+		otlpmetricgrpc.WithEndpoint(cfg.OpenTelAgentAddr),
+	)
+	if err != nil {
+		return err
+	}
+
+	meterProvider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(promExporter),
+		sdkmetric.WithReader(
+			sdkmetric.NewPeriodicReader(
+				otlpExporter,
+				sdkmetric.WithInterval(10*time.Second),
+			),
+		),
+	)
+
+	otel.SetMeterProvider(meterProvider)
+
+	err = setupCommonMetrics(GetMeter(cfg.ServiceName))
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := meterProvider.Shutdown(context.Background()); err != nil {
+			otel.Handle(err)
+		}
+	}()
+
+	return nil
+}
+
+func setupCommonMetrics(meter metric.Meter) error {
+	pending_count, err := meter.Int64UpDownCounter(
+		"pending_count",
+		metric.WithDescription("Total number of resources with status PENDING"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.Int64UpDownCounter(
+		"completed_count",
+		metric.WithDescription("Total number of resources with status COMPLETED"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.Int64UpDownCounter(
+		"error_counter",
+		metric.WithDescription("Total number of resources with status ERROR"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			// Simulate request count increment
+			pending_count.Add(context.Background(), 1,
+				metric.WithAttributes(attribute.String("status", "PENDING")),
+			)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	return nil
+}
+
+func GetMeter(name string) metric.Meter {
+	return otel.GetMeterProvider().Meter(name)
+}

--- a/pkg/telemetry/opentelemetry.go
+++ b/pkg/telemetry/opentelemetry.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
@@ -63,56 +62,10 @@ func setupMetrics(ctx context.Context, cfg Config, res *resource.Resource, mux *
 
 	otel.SetMeterProvider(meterProvider)
 
-	err = setupCommonMetrics(GetMeter(cfg.ServiceName))
-	if err != nil {
-		return err
-	}
-
 	go func() {
 		<-ctx.Done()
 		if err := meterProvider.Shutdown(context.Background()); err != nil {
 			otel.Handle(err)
-		}
-	}()
-
-	return nil
-}
-
-func setupCommonMetrics(meter metric.Meter) error {
-	pending_count, err := meter.Int64UpDownCounter(
-		"pending_count",
-		metric.WithDescription("Total number of resources with status PENDING"),
-		metric.WithUnit("1"),
-	)
-	if err != nil {
-		return err
-	}
-
-	_, err = meter.Int64UpDownCounter(
-		"completed_count",
-		metric.WithDescription("Total number of resources with status COMPLETED"),
-		metric.WithUnit("1"),
-	)
-	if err != nil {
-		return err
-	}
-
-	_, err = meter.Int64UpDownCounter(
-		"error_counter",
-		metric.WithDescription("Total number of resources with status ERROR"),
-		metric.WithUnit("1"),
-	)
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		for {
-			// Simulate request count increment
-			pending_count.Add(context.Background(), 1,
-				metric.WithAttributes(attribute.String("status", "PENDING")),
-			)
-			time.Sleep(5 * time.Second)
 		}
 	}()
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -27,9 +27,13 @@ type Config struct {
 	// OpenTelemetry Agent exporter.
 	EnableOtelAgent  bool   `mapstructure:"enable_otel_agent"`
 	OpenTelAgentAddr string `mapstructure:"otel_agent_addr"`
+
+	OTLPEndpoint  string `mapstructure:"otlp_endpoint"`
+	EnableMetrics bool   `mapstructure:"enable_metrics"`
+	EnableTraces  bool   `mapstructure:"enable_traces"`
 }
 
-// Init initialises OpenCensus based async-telemetry processes and
+// Init initialises OpenTelemetry based async-telemetry processes and
 // returns (i.e., it does not block).
 func Init(ctx context.Context, cfg Config) {
 	mux := http.NewServeMux()
@@ -38,9 +42,11 @@ func Init(ctx context.Context, cfg Config) {
 	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 
-	if err := setupOpenCensus(ctx, mux, cfg); err != nil {
-		zap.L().Error("failed to setup OpenCensus", zap.Error(err))
+	if err := setupOpenTelemetry(ctx, mux, cfg); err != nil {
+		zap.L().Error("failed to setup OpenTelemetry", zap.Error(err))
 	}
+
+	zap.L().Info("telemetry server started", zap.String("debug_addr", cfg.Debug))
 
 	if cfg.Debug != "" {
 		go func() {


### PR DESCRIPTION
Emit the following metrices
1. Retry - Retries happening with resource label
2. Resource status changing to ERROR, COMPLETED, PENDING