### PR TITLE
feat: add helm max history configuration

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -112,6 +112,7 @@ func (p *Client) doUpdate(actionConfig *action.Configuration, config *ReleaseCon
 	act.Timeout = time.Duration(config.Timeout) * time.Second
 	act.Namespace = config.Namespace
 	act.Description = config.Description
+	act.MaxHistory = p.config.Kubernetes.HelmConfig.MaxHistory
 
 	rel, err := act.Run(config.Name, fetchedChart, config.Values)
 	if err != nil {

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -15,6 +15,10 @@ const (
 	providerTypeGKE = "gke"
 )
 
+type HelmConfig struct {
+	MaxHistory int `json:"max_history" default:"256"`
+}
+
 type Config struct {
 	// Host - The hostname (in form of URI) of Kubernetes master.
 	Host string `json:"host"`
@@ -45,6 +49,8 @@ type Config struct {
 	// namespace is optional, if it is being defined, it will force all resources that depend
 	// on this kube resource to be deployed to the defined namespace
 	Namespace string `json:"namespace"`
+
+	HelmConfig HelmConfig `json:"helm_config"`
 }
 
 func (conf *Config) RESTConfig(ctx context.Context) (*rest.Config, error) {


### PR DESCRIPTION
default value is the helm default value for max history [[ref](https://helm.sh/docs/helm/helm_history/#:~:text=History%20prints%20historical%20revisions%20for,of%20the%20revision%20list%20returned.)]