### PR TITLE
feat: add burst and qps config

### DIFF
--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -51,6 +51,12 @@ type Config struct {
 	Namespace string `json:"namespace"`
 
 	HelmConfig HelmConfig `json:"helm_config"`
+
+	// Maximum burst for throttle.
+	Burst int `json:"burst" default:"-1"`
+
+	// QPS indicates the maximum QPS to the master from this client.
+	QPS float32 `json:"qps" default:"100"`
 }
 
 func (conf *Config) RESTConfig(ctx context.Context) (*rest.Config, error) {
@@ -84,6 +90,9 @@ func (conf *Config) RESTConfig(ctx context.Context) (*rest.Config, error) {
 	} else if conf.Token != "" {
 		rc.BearerToken = conf.Token
 	}
+
+	rc.Burst = conf.Burst
+	rc.QPS = conf.QPS
 
 	return rc, nil
 }

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -53,10 +53,10 @@ type Config struct {
 	HelmConfig HelmConfig `json:"helm_config"`
 
 	// Maximum burst for throttle.
-	Burst int `json:"burst" default:"1000"`
+	Burst int `json:"burst" default:"10"`
 
 	// QPS indicates the maximum QPS to the master from this client.
-	QPS float32 `json:"qps" default:"1000"`
+	QPS float32 `json:"qps" default:"5"`
 }
 
 func (conf *Config) RESTConfig(ctx context.Context) (*rest.Config, error) {

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -53,10 +53,10 @@ type Config struct {
 	HelmConfig HelmConfig `json:"helm_config"`
 
 	// Maximum burst for throttle.
-	Burst int `json:"burst" default:"-1"`
+	Burst int `json:"burst" default:"1000"`
 
 	// QPS indicates the maximum QPS to the master from this client.
-	QPS float32 `json:"qps" default:"100"`
+	QPS float32 `json:"qps" default:"1000"`
 }
 
 func (conf *Config) RESTConfig(ctx context.Context) (*rest.Config, error) {


### PR DESCRIPTION
On high load kube client throttles the request - https://github.com/helm/helm/issues/12154#issuecomment-1607693492 and we see [error](https://github.com/kubernetes/client-go/blob/1308d7c66b4a02200afba720e28091009cb25887/rest/request.go#L679) 