### PR TITLE
[phase-5] Add KAFKA to Firehose sink type schema

### DIFF
--- a/modules/firehose/schema/config.json
+++ b/modules/firehose/schema/config.json
@@ -54,7 +54,8 @@
             "REDIS",
             "BIGQUERY",
             "BIGTABLE",
-            "MAXCOMPUTE"
+            "MAXCOMPUTE",
+            "KAFKA"
           ]
         },
         "KAFKA_RECORD_PARSER_MODE": {


### PR DESCRIPTION
- Add KAFKA to SINK_TYPE enum in modules/firehose/schema/config.json
- Enables Entropy to validate and accept Kafka sink Firehose resources
- All SINK_KAFKA_* env vars pass through as generic env_variables