### PR TITLE
feat(firehose): declare limits/requests in config schema

### DIFF
--- a/modules/firehose/config.go
+++ b/modules/firehose/config.go
@@ -125,6 +125,10 @@ func readConfig(r resource.Resource, confJSON json.RawMessage, dc driverConf) (*
 	cfg.Limits = rl.Limits.merge(cfg.Limits)
 	cfg.Requests = rl.Requests.merge(cfg.Requests)
 
+	if err := (RequestsAndLimits{Limits: cfg.Limits, Requests: cfg.Requests}).Validate(); err != nil {
+		return nil, err
+	}
+
 	if cfg.Namespace == "" {
 		ns := dc.Namespace[defaultKey]
 		if override, ok := dc.Namespace[cfg.EnvVariables[confSinkType]]; ok {

--- a/modules/firehose/config_test.go
+++ b/modules/firehose/config_test.go
@@ -5,9 +5,113 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/goto/entropy/core/resource"
 	"github.com/goto/entropy/modules"
 )
+
+func testDriverConf() driverConf {
+	return driverConf{
+		Namespace: map[string]string{
+			defaultKey: "firehose",
+		},
+		ChartValues: ChartValues{
+			ImageRepository: imageRepo,
+			ImageTag:        "latest",
+			ChartVersion:    "0.1.3",
+			ImagePullPolicy: "IfNotPresent",
+		},
+		RequestsAndLimits: map[string]RequestsAndLimits{
+			defaultKey: {
+				Limits:   UsageSpec{CPU: "200m", Memory: "512Mi"},
+				Requests: UsageSpec{CPU: "200m", Memory: "512Mi"},
+			},
+		},
+	}
+}
+
+func baseEnvVariables() map[string]string {
+	return map[string]string{
+		"SINK_TYPE":                "LOG",
+		"INPUT_SCHEMA_PROTO_CLASS": "com.foo.Bar",
+		"SOURCE_KAFKA_BROKERS":     "localhost:9092",
+		"SOURCE_KAFKA_TOPIC":       "foo-log",
+	}
+}
+
+func Test_readConfig_limitsAndRequests(t *testing.T) {
+	t.Parallel()
+
+	res := resource.Resource{
+		URN:     "urn:goto:entropy:foo:fh1",
+		Kind:    "firehose",
+		Name:    "fh1",
+		Project: "foo",
+	}
+
+	t.Run("FullOverride", func(t *testing.T) {
+		conf := modules.MustJSON(map[string]any{
+			"replicas":      1,
+			"env_variables": baseEnvVariables(),
+			"limits":        map[string]any{"cpu": "500m", "memory": "2048Mi"},
+			"requests":      map[string]any{"cpu": "400m", "memory": "1024Mi"},
+		})
+
+		got, err := readConfig(res, conf, testDriverConf())
+		require.NoError(t, err)
+		assert.Equal(t, UsageSpec{CPU: "500m", Memory: "2048Mi"}, got.Limits)
+		assert.Equal(t, UsageSpec{CPU: "400m", Memory: "1024Mi"}, got.Requests)
+	})
+
+	t.Run("PartialOverride_InheritsDriverDefault", func(t *testing.T) {
+		conf := modules.MustJSON(map[string]any{
+			"replicas":      1,
+			"env_variables": baseEnvVariables(),
+			"limits":        map[string]any{"cpu": "500m"},
+		})
+
+		got, err := readConfig(res, conf, testDriverConf())
+		require.NoError(t, err)
+		// cpu is overridden, memory falls back to the driver default.
+		assert.Equal(t, UsageSpec{CPU: "500m", Memory: "512Mi"}, got.Limits)
+		// requests entirely omitted -> both fields from driver default.
+		assert.Equal(t, UsageSpec{CPU: "200m", Memory: "512Mi"}, got.Requests)
+	})
+
+	t.Run("Omitted_UsesDriverDefault", func(t *testing.T) {
+		conf := modules.MustJSON(map[string]any{
+			"replicas":      1,
+			"env_variables": baseEnvVariables(),
+		})
+
+		got, err := readConfig(res, conf, testDriverConf())
+		require.NoError(t, err)
+		assert.Equal(t, UsageSpec{CPU: "200m", Memory: "512Mi"}, got.Limits)
+		assert.Equal(t, UsageSpec{CPU: "200m", Memory: "512Mi"}, got.Requests)
+	})
+
+	invalid := []struct {
+		name  string
+		limit any
+	}{
+		{name: "CPUAsNumber", limit: map[string]any{"cpu": 500}},
+		{name: "UnknownKey", limit: map[string]any{"cpus": "500m"}},
+		{name: "NotAnObject", limit: "500m"},
+	}
+	for _, tt := range invalid {
+		t.Run("Invalid_"+tt.name, func(t *testing.T) {
+			conf := modules.MustJSON(map[string]any{
+				"replicas":      1,
+				"env_variables": baseEnvVariables(),
+				"limits":        tt.limit,
+			})
+
+			_, err := readConfig(res, conf, testDriverConf())
+			assert.Error(t, err)
+		})
+	}
+}
 
 func Test_safeReleaseName(t *testing.T) {
 	t.Parallel()

--- a/modules/firehose/config_test.go
+++ b/modules/firehose/config_test.go
@@ -111,6 +111,30 @@ func Test_readConfig_limitsAndRequests(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+
+	t.Run("Invalid_MergedRequestsExceedDriverDefaultLimits", func(t *testing.T) {
+		// driver default limits.cpu is 200m; requesting more than that
+		// without also raising the limit must be rejected.
+		conf := modules.MustJSON(map[string]any{
+			"replicas":      1,
+			"env_variables": baseEnvVariables(),
+			"requests":      map[string]any{"cpu": "500m"},
+		})
+
+		_, err := readConfig(res, conf, testDriverConf())
+		assert.Error(t, err)
+	})
+
+	t.Run("Invalid_MergedLimitsCPUIsZero", func(t *testing.T) {
+		conf := modules.MustJSON(map[string]any{
+			"replicas":      1,
+			"env_variables": baseEnvVariables(),
+			"limits":        map[string]any{"cpu": "0"},
+		})
+
+		_, err := readConfig(res, conf, testDriverConf())
+		assert.Error(t, err)
+	})
 }
 
 func Test_safeReleaseName(t *testing.T) {

--- a/modules/firehose/driver.go
+++ b/modules/firehose/driver.go
@@ -9,6 +9,8 @@ import (
 	"text/template"
 	"time"
 
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/goto/entropy/core/module"
 	"github.com/goto/entropy/core/resource"
 	"github.com/goto/entropy/modules"
@@ -158,6 +160,50 @@ type Triggers map[string]Trigger
 type RequestsAndLimits struct {
 	Limits   UsageSpec `json:"limits,omitempty"`
 	Requests UsageSpec `json:"requests,omitempty"`
+}
+
+func parseUsageQuantity(field, value string) (k8sresource.Quantity, error) {
+	q, err := k8sresource.ParseQuantity(value)
+	if err != nil {
+		return k8sresource.Quantity{}, errors.ErrInvalid.
+			WithMsgf("invalid %s value: '%s'", field, value).
+			WithCausef("%s", err.Error())
+	}
+	if q.Sign() <= 0 {
+		return k8sresource.Quantity{}, errors.ErrInvalid.
+			WithMsgf("%s must be a positive value, got '%s'", field, value)
+	}
+	return q, nil
+}
+
+// Validate ensures the limits/requests are valid, positive Kubernetes resource
+// quantities and that requests do not exceed limits, for both cpu and memory.
+func (rl RequestsAndLimits) Validate() error {
+	limitsCPU, err := parseUsageQuantity("limits.cpu", rl.Limits.CPU)
+	if err != nil {
+		return err
+	}
+	limitsMemory, err := parseUsageQuantity("limits.memory", rl.Limits.Memory)
+	if err != nil {
+		return err
+	}
+	requestsCPU, err := parseUsageQuantity("requests.cpu", rl.Requests.CPU)
+	if err != nil {
+		return err
+	}
+	requestsMemory, err := parseUsageQuantity("requests.memory", rl.Requests.Memory)
+	if err != nil {
+		return err
+	}
+
+	if requestsCPU.Cmp(limitsCPU) > 0 {
+		return errors.ErrInvalid.WithMsgf("requests.cpu (%s) must not exceed limits.cpu (%s)", rl.Requests.CPU, rl.Limits.CPU)
+	}
+	if requestsMemory.Cmp(limitsMemory) > 0 {
+		return errors.ErrInvalid.WithMsgf("requests.memory (%s) must not exceed limits.memory (%s)", rl.Requests.Memory, rl.Limits.Memory)
+	}
+
+	return nil
 }
 
 type InitContainer struct {

--- a/modules/firehose/driver_test.go
+++ b/modules/firehose/driver_test.go
@@ -698,3 +698,93 @@ func firehoseDriverConf() driverConf {
 		},
 	}
 }
+
+func Test_RequestsAndLimits_Validate(t *testing.T) {
+	t.Parallel()
+
+	valid := RequestsAndLimits{
+		Limits:   UsageSpec{CPU: "500m", Memory: "1Gi"},
+		Requests: UsageSpec{CPU: "200m", Memory: "512Mi"},
+	}
+
+	table := []struct {
+		title   string
+		rl      RequestsAndLimits
+		wantErr bool
+	}{
+		{
+			title:   "Valid_RequestsWithinLimits",
+			rl:      valid,
+			wantErr: false,
+		},
+		{
+			// Kubernetes treats a bare number as a valid quantity (bytes for
+			// memory, cores for cpu) - this must NOT be rejected as a format error.
+			title: "Valid_BareNumberSuffix",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "2", Memory: "2147483648"},
+				Requests: UsageSpec{CPU: "1", Memory: "1073741824"},
+			},
+			wantErr: false,
+		},
+		{
+			title: "Invalid_UnparseableCPU",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "abc", Memory: "1Gi"},
+				Requests: valid.Requests,
+			},
+			wantErr: true,
+		},
+		{
+			title: "Invalid_UnrecognizedSuffix",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "5xyz", Memory: "1Gi"},
+				Requests: valid.Requests,
+			},
+			wantErr: true,
+		},
+		{
+			title: "Invalid_ZeroLimit",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "0", Memory: "1Gi"},
+				Requests: valid.Requests,
+			},
+			wantErr: true,
+		},
+		{
+			title: "Invalid_NegativeRequest",
+			rl: RequestsAndLimits{
+				Limits:   valid.Limits,
+				Requests: UsageSpec{CPU: "-100m", Memory: "512Mi"},
+			},
+			wantErr: true,
+		},
+		{
+			title: "Invalid_RequestsCPUExceedsLimits",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "100m", Memory: "1Gi"},
+				Requests: UsageSpec{CPU: "200m", Memory: "512Mi"},
+			},
+			wantErr: true,
+		},
+		{
+			title: "Invalid_RequestsMemoryExceedsLimits",
+			rl: RequestsAndLimits{
+				Limits:   UsageSpec{CPU: "500m", Memory: "256Mi"},
+				Requests: UsageSpec{CPU: "200m", Memory: "512Mi"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.title, func(t *testing.T) {
+			err := tt.rl.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/modules/firehose/module.go
+++ b/modules/firehose/module.go
@@ -83,6 +83,14 @@ var Module = module.Descriptor{
 			return nil, err
 		}
 
+		for sinkType, rl := range conf.RequestsAndLimits {
+			if err := rl.Validate(); err != nil {
+				return nil, errors.ErrInvalid.
+					WithMsgf("invalid requests_and_limits for sink type '%s'", sinkType).
+					WithCausef("%s", err.Error())
+			}
+		}
+
 		return &firehoseDriver{
 			conf:    conf,
 			timeNow: time.Now,

--- a/modules/firehose/schema/config.json
+++ b/modules/firehose/schema/config.json
@@ -19,6 +19,12 @@
     "deployment_id": {
       "type": "string"
     },
+    "limits": {
+      "$ref": "#/definitions/usageSpec"
+    },
+    "requests": {
+      "$ref": "#/definitions/usageSpec"
+    },
     "env_variables": {
       "type": "object",
       "additionalProperties": true,
@@ -83,6 +89,20 @@
           "type": "object"
         }
       }
+    }
+  },
+  "definitions": {
+    "usageSpec": {
+      "type": "object",
+      "properties": {
+        "cpu": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/modules/firehose/test/module-config.json
+++ b/modules/firehose/test/module-config.json
@@ -327,12 +327,12 @@
     "requests_and_limits": {
         "default": {
             "limits": {
-                "cpu": "dummy_cpu_limit",
-                "memory": "dummy_memory_limit"
+                "cpu": "500m",
+                "memory": "1Gi"
             },
             "requests": {
-                "cpu": "dummy_cpu_request",
-                "memory": "dummy_memory_request"
+                "cpu": "200m",
+                "memory": "512Mi"
             }
         }
     },


### PR DESCRIPTION
CPU/memory resource overrides already flowed through readConfig and into the Helm values, but were undeclared in the JSON schema, so malformed values (wrong type, typoed keys) were silently accepted.