### PR TITLE
feat(dagger): add CSV sink support

### DIFF
--- a/modules/dagger/config.go
+++ b/modules/dagger/config.go
@@ -62,6 +62,7 @@ const (
 	SinkTypeInflux   = "INFLUX"
 	SinkTypeKafka    = "KAFKA"
 	SinkTypeBigquery = "BIGQUERY"
+	SinkTypeCSV      = "CSV"
 )
 
 // BigQuery-related constants
@@ -85,6 +86,17 @@ const (
 	keySinkConnectorSchemaProtoMessageClass = "SINK_CONNECTOR_SCHEMA_PROTO_MESSAGE_CLASS"
 	keySinkKafkaProduceLargeMessageEnable   = "SINK_KAFKA_PRODUCE_LARGE_MESSAGE_ENABLE"
 	keySinkBigqueryCredentialPath           = "SINK_BIGQUERY_CREDENTIAL_PATH"
+)
+
+// CSV-related constants
+const (
+	keySinkCsvBasePath            = "SINK_CSV_BASE_PATH"
+	keySinkCsvWriteMode           = "SINK_CSV_WRITE_MODE"
+	keySinkCsvPartitionDateFormat = "SINK_CSV_PARTITION_DATE_FORMAT"
+	keySinkCsvPartitionTimezone   = "SINK_CSV_PARTITION_TIMEZONE"
+	keySinkCsvDelimiter           = "SINK_CSV_DELIMITER"
+	keySinkCsvWriteHeader         = "SINK_CSV_WRITE_HEADER"
+	keySinkCsvFilenamePrefix      = "SINK_CSV_FILENAME_PREFIX"
 )
 
 var (
@@ -213,10 +225,21 @@ type SinkBigquery struct {
 	SinkConnectorSchemaProtoMessageClass string `json:"SINK_CONNECTOR_SCHEMA_PROTO_MESSAGE_CLASS"`
 }
 
+type SinkCSV struct {
+	SinkCsvBasePath            string `json:"SINK_CSV_BASE_PATH,omitempty"`
+	SinkCsvWriteMode           string `json:"SINK_CSV_WRITE_MODE,omitempty"`
+	SinkCsvPartitionDateFormat string `json:"SINK_CSV_PARTITION_DATE_FORMAT,omitempty"`
+	SinkCsvPartitionTimezone   string `json:"SINK_CSV_PARTITION_TIMEZONE,omitempty"`
+	SinkCsvDelimiter           string `json:"SINK_CSV_DELIMITER,omitempty"`
+	SinkCsvWriteHeader         string `json:"SINK_CSV_WRITE_HEADER,omitempty"`
+	SinkCsvFilenamePrefix      string `json:"SINK_CSV_FILENAME_PREFIX,omitempty"`
+}
+
 type Sink struct {
 	SinkKafka
 	SinkInflux
 	SinkBigquery
+	SinkCSV
 }
 
 func readConfig(r module.ExpandedResource, confJSON json.RawMessage, dc driverConf) (*Config, error) {
@@ -362,6 +385,31 @@ func readConfig(r module.ExpandedResource, confJSON json.RawMessage, dc driverCo
 		cfg.EnvVariables[keySinkBigqueryTableClusteringKeys] = cfg.Sink.SinkBigquery.SinkBigqueryTableClusteringKeys
 		cfg.EnvVariables[keySinkErrorTypesForFailure] = cfg.Sink.SinkBigquery.SinkErrorTypesForFailure
 		cfg.EnvVariables[keySinkConnectorSchemaProtoMessageClass] = cfg.Sink.SinkBigquery.SinkConnectorSchemaProtoMessageClass
+	} else if cfg.SinkType == SinkTypeCSV {
+		if cfg.Sink.SinkCSV.SinkCsvBasePath == "" {
+			return nil, errors.ErrInvalid.WithMsgf("SINK_CSV_BASE_PATH is required for csv sink")
+		}
+		cfg.EnvVariables[keySinkCsvBasePath] = cfg.Sink.SinkCSV.SinkCsvBasePath
+
+		// optional keys: emit only when provided so the Dagger app's own defaults apply otherwise
+		if v := cfg.Sink.SinkCSV.SinkCsvWriteMode; v != "" {
+			cfg.EnvVariables[keySinkCsvWriteMode] = v
+		}
+		if v := cfg.Sink.SinkCSV.SinkCsvPartitionDateFormat; v != "" {
+			cfg.EnvVariables[keySinkCsvPartitionDateFormat] = v
+		}
+		if v := cfg.Sink.SinkCSV.SinkCsvPartitionTimezone; v != "" {
+			cfg.EnvVariables[keySinkCsvPartitionTimezone] = v
+		}
+		if v := cfg.Sink.SinkCSV.SinkCsvDelimiter; v != "" {
+			cfg.EnvVariables[keySinkCsvDelimiter] = v
+		}
+		if v := cfg.Sink.SinkCSV.SinkCsvWriteHeader; v != "" {
+			cfg.EnvVariables[keySinkCsvWriteHeader] = v
+		}
+		if v := cfg.Sink.SinkCSV.SinkCsvFilenamePrefix; v != "" {
+			cfg.EnvVariables[keySinkCsvFilenamePrefix] = v
+		}
 	}
 
 	//transformation #2

--- a/modules/dagger/config_test.go
+++ b/modules/dagger/config_test.go
@@ -1,0 +1,111 @@
+package dagger
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/goto/entropy/core/module"
+	"github.com/goto/entropy/core/resource"
+)
+
+func csvExpandedResource() module.ExpandedResource {
+	return module.ExpandedResource{
+		Resource: resource.Resource{
+			URN:     "orn:entropy:dagger:test:csv-test",
+			Kind:    "dagger",
+			Name:    "csv-test",
+			Project: "test-project",
+		},
+		Dependencies: map[string]module.ResolvedDependency{
+			keyFlinkDependency: {
+				Kind:   "flink",
+				Output: json.RawMessage(`{"kube_namespace":"test-ns"}`),
+			},
+		},
+	}
+}
+
+func csvConfigJSON(t *testing.T, sink map[string]string) json.RawMessage {
+	t.Helper()
+	cfg := map[string]any{
+		"replicas":  1,
+		"team":      "test-team",
+		"sink_type": SinkTypeCSV,
+		"source": []map[string]any{
+			{"SOURCE_KAFKA_CONSUMER_CONFIG_GROUP_ID": "test-0001"},
+		},
+		"sink":          sink,
+		"env_variables": map[string]string{keySinkType: SinkTypeCSV},
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	return b
+}
+
+func TestReadConfigCSVSink(t *testing.T) {
+	sink := map[string]string{
+		keySinkCsvBasePath:  "gs://bucket/some-folder",
+		keySinkCsvWriteMode: "OVERWRITE",
+	}
+
+	cfg, err := readConfig(csvExpandedResource(), csvConfigJSON(t, sink), driverConf{})
+	if err != nil {
+		t.Fatalf("readConfig returned error: %v", err)
+	}
+
+	if got := cfg.EnvVariables[keySinkType]; got != SinkTypeCSV {
+		t.Errorf("SINK_TYPE = %q, want %q", got, SinkTypeCSV)
+	}
+	if got := cfg.EnvVariables[keySinkCsvBasePath]; got != "gs://bucket/some-folder" {
+		t.Errorf("SINK_CSV_BASE_PATH = %q, want %q", got, "gs://bucket/some-folder")
+	}
+	if got := cfg.EnvVariables[keySinkCsvWriteMode]; got != "OVERWRITE" {
+		t.Errorf("SINK_CSV_WRITE_MODE = %q, want %q", got, "OVERWRITE")
+	}
+
+	// Optional keys that were not provided must NOT be emitted, so the Dagger app's
+	// own defaults (delimiter, timezone, header, ...) are not clobbered with empty strings.
+	if v, ok := cfg.EnvVariables[keySinkCsvDelimiter]; ok {
+		t.Errorf("SINK_CSV_DELIMITER should be absent, got %q", v)
+	}
+	if v, ok := cfg.EnvVariables[keySinkCsvPartitionTimezone]; ok {
+		t.Errorf("SINK_CSV_PARTITION_TIMEZONE should be absent, got %q", v)
+	}
+}
+
+func TestReadConfigCSVSinkRequiresBasePath(t *testing.T) {
+	cfg, err := readConfig(csvExpandedResource(), csvConfigJSON(t, map[string]string{}), driverConf{})
+	if err == nil {
+		t.Fatalf("expected error for missing SINK_CSV_BASE_PATH, got nil (cfg=%+v)", cfg)
+	}
+	if !strings.Contains(err.Error(), keySinkCsvBasePath) {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), keySinkCsvBasePath)
+	}
+}
+
+func TestValidateConfigSinkTypeEnum(t *testing.T) {
+	// CSV must now be accepted by the embedded JSON schema.
+	if err := validateConfig(csvConfigJSON(t, map[string]string{keySinkCsvBasePath: "gs://b/f"})); err != nil {
+		t.Errorf("validateConfig rejected CSV sink_type: %v", err)
+	}
+
+	// An unknown sink type must still be rejected by the schema.
+	bad := map[string]any{
+		"replicas":      1,
+		"team":          "test-team",
+		"sink_type":     "PARQUET",
+		"source":        []map[string]any{{"SOURCE_KAFKA_CONSUMER_CONFIG_GROUP_ID": "test-0001"}},
+		"sink":          map[string]string{},
+		"env_variables": map[string]string{keySinkType: "PARQUET"},
+	}
+	b, err := json.Marshal(bad)
+	if err != nil {
+		t.Fatalf("marshal bad config: %v", err)
+	}
+	if err := validateConfig(json.RawMessage(b)); err == nil {
+		t.Error("validateConfig accepted unknown sink_type PARQUET, want rejection")
+	}
+}

--- a/modules/dagger/schema/config.json
+++ b/modules/dagger/schema/config.json
@@ -24,7 +24,8 @@
         "enum": [
           "INFLUX",
           "KAFKA",
-          "BIGQUERY"
+          "BIGQUERY",
+          "CSV"
         ]
       },
       "env_variables": {
@@ -39,7 +40,8 @@
             "enum": [
               "INFLUX",
               "KAFKA",
-              "BIGQUERY"
+              "BIGQUERY",
+              "CSV"
             ]
           }
         }


### PR DESCRIPTION
Mirror the existing Kafka/Influx/BigQuery handling to make CSV a first-class Dagger sink type:
https://github.com/goto/dagger/pull/71

- allow SINK_TYPE=CSV in the config JSON schema (both enums)
- add SinkTypeCSV, SINK_CSV_* key constants, and the SinkCSV struct (embedded in Sink)
- translate SINK_CSV_* into env vars in readConfig; require SINK_CSV_BASE_PATH and emit optional keys only when set so the Dagger app's own defaults are preserved
- add config_test.go covering translation, the base-path guard, and the schema enum