### PR TITLE
feat: add acl and service account config for dagger and kafka module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+.claude
 
 # Test binary, built with `go test -c`
 *.test

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -70,7 +70,7 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 	}
 
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
-	moduleService := module.NewService(setupRegistry(), store)
+	moduleService := module.NewService(setupRegistry(store), store)
 	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries, cfg.Telemetry.ServiceName)
 
 	if migrate {
@@ -95,14 +95,16 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 	)
 }
 
-func setupRegistry() module.Registry {
+func setupRegistry(store *postgres.Store) module.Registry {
 	supported := []module.Descriptor{
 		kubernetes.Module,
 		firehose.Module,
 		job.Module,
 		kafka.Module,
 		flink.Module,
-		dagger.Module,
+		// dagger resolves ACL kafka streams by fetching their resource internally
+		// (no dependency), so it needs a resource getter backed by the store.
+		dagger.Module(store.GetByURN),
 	}
 
 	registry := &modules.Registry{}

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -72,8 +72,6 @@ func StartServer(ctx context.Context, cfg Config, migrate, spawnWorker bool) err
 	}
 
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
-	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries, cfg.Telemetry.ServiceName)
-	
 	moduleService := module.NewService(setupRegistry(store), store)
 
 	// TODO: Securely load this value from an environment variable or secrets

--- a/cli/worker.go
+++ b/cli/worker.go
@@ -59,7 +59,7 @@ func cmdWorker() *cobra.Command {
 
 func StartWorkers(ctx context.Context, cfg Config) error {
 	store := setupStorage(cfg.PGConnStr, cfg.Syncer, cfg.Service)
-	moduleService := module.NewService(setupRegistry(), store)
+	moduleService := module.NewService(setupRegistry(store), store)
 	resourceService := core.New(store, moduleService, time.Now, cfg.Syncer.SyncBackoffInterval, cfg.Syncer.MaxRetries, cfg.Telemetry.ServiceName)
 
 	eg := &errgroup.Group{}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.11.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	go.nhat.io/otelsql v0.16.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
@@ -49,7 +50,6 @@ require (
 
 require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	go.nhat.io/otelsql v0.16.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -93,6 +93,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=
+github.com/bool64/shared v0.1.5/go.mod h1:081yz68YC9jeFB3+Bbmno2RFWvGKv1lPKkMP6MHJlPs=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
@@ -194,8 +196,6 @@ github.com/foxcpp/go-mockdns v1.0.0/go.mod h1:lgRN6+KxQBawyIghpnl5CezHFGS9VLzvtV
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
@@ -380,6 +380,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -452,8 +454,6 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -597,9 +597,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
-github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -643,6 +642,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/swaggest/assertjson v1.9.0 h1:dKu0BfJkIxv/xe//mkCrK5yZbs79jL7OVf9Ija7o2xQ=
+github.com/swaggest/assertjson v1.9.0/go.mod h1:b+ZKX2VRiUjxfUIal0HDN85W0nHPAYUbYH5WkkSsFsU=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -660,6 +661,10 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
+github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -700,6 +705,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.45.0 h1:tfi
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.45.0/go.mod h1:AKFZIEPOnqB00P63bTjOiah4ZTaRzl1TKwUWpZdYUHI=
 go.opentelemetry.io/otel/exporters/prometheus v0.56.0 h1:GnCIi0QyG0yy2MrJLzVrIM7laaJstj//flf1zEJCG+E=
 go.opentelemetry.io/otel/exporters/prometheus v0.56.0/go.mod h1:JQcVZtbIIPM+7SWBB+T6FK+xunlyidwLp++fN0sUaOk=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.24.0 h1:JYE2HM7pZbOt5Jhk8ndWZTUWYOVift2cHjXVMkPdmdc=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.24.0/go.mod h1:yMb/8c6hVsnma0RpsBMNo0fEiQKeclawtgaIaOp2MLY=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.24.0 h1:s0PHtIkN+3xrbDOpt2M8OTG92cWqUESvzh2MxiR5xY8=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.24.0/go.mod h1:hZlFbDbRt++MMPCCfSJfmhkGIWnX1h3XjkfxZUjLrIA=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
 go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
 go.opentelemetry.io/otel/sdk v1.38.0 h1:l48sr5YbNf2hpCUj/FoGhW9yDkl+Ma+LrVl8qaM5b+E=
@@ -888,7 +897,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/modules/dagger/config.go
+++ b/modules/dagger/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goto/entropy/core/module"
 	"github.com/goto/entropy/modules"
 	"github.com/goto/entropy/modules/flink"
+	kafkamod "github.com/goto/entropy/modules/kafka"
 	"github.com/goto/entropy/pkg/errors"
 	"github.com/goto/entropy/pkg/validator"
 )
@@ -141,9 +142,13 @@ type Config struct {
 	TaskManagerServiceAccount string `json:"taskmanager_service_account,omitempty"`
 
 	// ACLMounts is the set of secret / projected-token volume mounts required by
-	// ACL (SASL_SSL/OAUTHBEARER, SSL, PLAIN/SCRAM) source streams. It is
-
+	// ACL (SASL_SSL/OAUTHBEARER, SSL, PLAIN/SCRAM) source streams. It is computed
+	// by applyStreamSecurity from the resolved stream security profiles.
 	ACLMounts []ACLMount `json:"acl_mounts,omitempty"`
+
+	// StreamSecurity holds the kafka security profile fetched by Dex, keyed by
+	// SOURCE_KAFKA_NAME. References only — never inline secret values.
+	StreamSecurity map[string]*kafkamod.SecurityProfile `json:"stream_security,omitempty"`
 }
 
 // ACLMount describes a single podTemplate volume+mount for an ACL stream.

--- a/modules/dagger/config.go
+++ b/modules/dagger/config.go
@@ -133,6 +133,26 @@ type Config struct {
 	DaggerK8sHAURL      string            `json:"dagger_k8s_ha_url,omitempty"`
 	CloudProvider       string            `json:"cloud_provider,omitempty"`
 	FSOSSEndpoint       string            `json:"fs_oss_endpoint,omitempty"`
+
+	// TaskManagerServiceAccount, when set, becomes
+	// kubernetes.taskmanager.service-account in the FlinkDeployment. It is the
+	// OAuth identity aegis-kafka authorized for ACL streams. Empty preserves the
+	// default (serviceAccount: flink) behaviour.
+	TaskManagerServiceAccount string `json:"taskmanager_service_account,omitempty"`
+
+	// ACLMounts is the set of secret / projected-token volume mounts required by
+	// ACL (SASL_SSL/OAUTHBEARER, SSL, PLAIN/SCRAM) source streams. It is
+
+	ACLMounts []ACLMount `json:"acl_mounts,omitempty"`
+}
+
+// ACLMount describes a single podTemplate volume+mount for an ACL stream.
+// Type is either "secret" or "projected".
+type ACLMount struct {
+	Name       string `json:"name"`
+	MountPath  string `json:"mountPath"`
+	SecretName string `json:"secretName,omitempty"`
+	Type       string `json:"type"`
 }
 
 type ChartValues struct {
@@ -154,6 +174,10 @@ type SourceKafka struct {
 	SourceKafkaName                           string `json:"SOURCE_KAFKA_NAME"`
 	SourceKafkaConsumerConfigGroupID          string `json:"SOURCE_KAFKA_CONSUMER_CONFIG_GROUP_ID"`
 	SourceKafkaConsumerConfigBootstrapServers string `json:"SOURCE_KAFKA_CONSUMER_CONFIG_BOOTSTRAP_SERVERS"`
+	// SourceKafkaConsumerAdditionalConfigurations carries the SASL/SSL consumer
+	// config for ACL streams. It is nil for plaintext streams so that STREAMS
+	// stays byte-for-byte identical to the pre-ACL behaviour.
+	SourceKafkaConsumerAdditionalConfigurations map[string]interface{} `json:"SOURCE_KAFKA_CONSUMER_ADDITIONAL_CONFIGURATIONS,omitempty"`
 }
 
 type SourceParquet struct {

--- a/modules/dagger/config.go
+++ b/modules/dagger/config.go
@@ -179,6 +179,7 @@ type SourceKafka struct {
 	SourceKafkaName                           string `json:"SOURCE_KAFKA_NAME"`
 	SourceKafkaConsumerConfigGroupID          string `json:"SOURCE_KAFKA_CONSUMER_CONFIG_GROUP_ID"`
 	SourceKafkaConsumerConfigBootstrapServers string `json:"SOURCE_KAFKA_CONSUMER_CONFIG_BOOTSTRAP_SERVERS"`
+	SourceKafkaSecurityEnabled                bool   `json:"SOURCE_KAFKA_SECURITY_ENABLED,omitempty"`
 	// SourceKafkaConsumerAdditionalConfigurations carries the SASL/SSL consumer
 	// config for ACL streams. It is nil for plaintext streams so that STREAMS
 	// stays byte-for-byte identical to the pre-ACL behaviour.

--- a/modules/dagger/driver.go
+++ b/modules/dagger/driver.go
@@ -255,6 +255,16 @@ func (dd *daggerDriver) getHelmRelease(res resource.Resource, conf Config,
 	requiredDuringSchedulingIgnoredDuringExecutionInterface := kubernetes.PreferenceSliceToInterfaceSlice(requiredDuringSchedulingIgnoredDuringExecution)
 	preferredDuringSchedulingIgnoredDuringExecutionInterface := kubernetes.WeightedPreferencesToInterfaceSlice(preferredDuringSchedulingIgnoredDuringExecution)
 
+	aclMounts := make([]map[string]any, 0, len(conf.ACLMounts))
+	for _, m := range conf.ACLMounts {
+		aclMounts = append(aclMounts, map[string]any{
+			"name":       m.Name,
+			"mountPath":  m.MountPath,
+			"secretName": m.SecretName,
+			"type":       m.Type,
+		})
+	}
+
 	rc.Values = map[string]any{
 		labelsConfKey:   modules.CloneAndMergeMaps(deploymentLabels, entropyLabels),
 		"image":         imageRepository,
@@ -292,6 +302,10 @@ func (dd *daggerDriver) getHelmRelease(res resource.Resource, conf Config,
 			"requiredDuringSchedulingIgnoredDuringExecution":  requiredDuringSchedulingIgnoredDuringExecutionInterface,
 			"preferredDuringSchedulingIgnoredDuringExecution": preferredDuringSchedulingIgnoredDuringExecutionInterface,
 		},
+		// ACL (SASL/SSL) source support. Empty for plaintext daggers, which keeps
+		// the rendered FlinkDeployment byte-for-byte identical to before.
+		"acl_mounts":                             aclMounts,
+		"kubernetes_taskmanager_service_account": conf.TaskManagerServiceAccount,
 	}
 
 	return rc, nil

--- a/modules/dagger/driver.go
+++ b/modules/dagger/driver.go
@@ -69,7 +69,10 @@ type daggerDriver struct {
 	kubeGetCRD       kubeGetCRDFn
 	consumerReset    consumerResetFn
 	kubeProxyService kubeProxyServiceFn
+	getResource      ResourceGetter
 }
+
+type ResourceGetter func(ctx context.Context, urn string) (*resource.Resource, error)
 
 type (
 	kubeDeployFn       func(ctx context.Context, isCreate bool, conf kube.Config, hc helm.ReleaseConfig) error

--- a/modules/dagger/driver_plan.go
+++ b/modules/dagger/driver_plan.go
@@ -24,33 +24,33 @@ const (
 	KeySchemaRegistryStencilURLs             = "SCHEMA_REGISTRY_STENCIL_URLS"
 )
 
-func (dd *daggerDriver) Plan(_ context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
+func (dd *daggerDriver) Plan(ctx context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	switch act.Name {
 	case module.CreateAction:
-		return dd.planCreate(exr, act)
+		return dd.planCreate(ctx, exr, act)
 
 	case ResetAction:
-		return dd.planReset(exr, act)
+		return dd.planReset(ctx, exr, act)
 
 	default:
-		return dd.planChange(exr, act)
+		return dd.planChange(ctx, exr, act)
 	}
 }
 
-func (dd *daggerDriver) planCreate(exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
+func (dd *daggerDriver) planCreate(ctx context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	conf, err := readConfig(exr, act.Params, dd.conf)
 	if err != nil {
 		return nil, err
 	}
 
-	// resolve ACL source streams (bootstrap servers + SASL/SSL consumer config +
-	// podTemplate mounts). No-op for plaintext sources.
-	if err := applyStreamSecurity(exr, conf); err != nil {
+	// resolve ACL source streams (SASL/SSL consumer config + podTemplate mounts).
+	// No-op for plaintext sources.
+	if err := dd.applyStreamSecurity(ctx, exr, conf); err != nil {
 		return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
 	}
 
 	//transformation #12
-	conf.EnvVariables[keyStreams] = string(mustMarshalJSON(conf.Source))
+	conf.EnvVariables[keyStreams] = streamsJSON(conf.Source)
 	conf.EnvVariables[keyFlinkParallelism] = fmt.Sprint(conf.Replicas)
 
 	chartVals := mergeChartValues(&dd.conf.ChartValues, conf.ChartValues)
@@ -89,7 +89,7 @@ func (dd *daggerDriver) planCreate(exr module.ExpandedResource, act module.Actio
 	return &exr.Resource, nil
 }
 
-func (dd *daggerDriver) planChange(exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
+func (dd *daggerDriver) planChange(ctx context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	curConf, err := readConfig(exr, exr.Resource.Spec.Configs, dd.conf)
 	if err != nil {
 		return nil, err
@@ -103,10 +103,10 @@ func (dd *daggerDriver) planChange(exr module.ExpandedResource, act module.Actio
 		}
 
 		newConf.Source = mergeConsumerGroupId(curConf.Source, newConf.Source)
-		if err := applyStreamSecurity(exr, newConf); err != nil {
+		if err := dd.applyStreamSecurity(ctx, exr, newConf); err != nil {
 			return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
 		}
-		newConf.EnvVariables[keyStreams] = string(mustMarshalJSON(newConf.Source))
+		newConf.EnvVariables[keyStreams] = streamsJSON(newConf.Source)
 		newConf.EnvVariables[keyFlinkParallelism] = fmt.Sprint(newConf.Replicas)
 
 		//we want to update these irrespective of the user input
@@ -173,7 +173,7 @@ func (dd *daggerDriver) planChange(exr module.ExpandedResource, act module.Actio
 	return &exr.Resource, nil
 }
 
-func (dd *daggerDriver) planReset(exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
+func (dd *daggerDriver) planReset(ctx context.Context, exr module.ExpandedResource, act module.ActionRequest) (*resource.Resource, error) {
 	resetValue, err := kafka.ParseResetV2Params(act.Params)
 	if err != nil {
 		return nil, err
@@ -194,10 +194,10 @@ func (dd *daggerDriver) planReset(exr module.ExpandedResource, act module.Action
 	curConf.ResetOffset = resetValue
 
 	curConf.Source = dd.consumerReset(context.Background(), *curConf, resetValue)
-	if err := applyStreamSecurity(exr, curConf); err != nil {
+	if err := dd.applyStreamSecurity(ctx, exr, curConf); err != nil {
 		return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
 	}
-	curConf.EnvVariables[keyStreams] = string(mustMarshalJSON(curConf.Source))
+	curConf.EnvVariables[keyStreams] = streamsJSON(curConf.Source)
 
 	curConf.ChartValues = &dd.conf.ChartValues
 	curConf.JarURI = dd.conf.JarURI

--- a/modules/dagger/driver_plan.go
+++ b/modules/dagger/driver_plan.go
@@ -43,6 +43,12 @@ func (dd *daggerDriver) planCreate(exr module.ExpandedResource, act module.Actio
 		return nil, err
 	}
 
+	// resolve ACL source streams (bootstrap servers + SASL/SSL consumer config +
+	// podTemplate mounts). No-op for plaintext sources.
+	if err := applyStreamSecurity(exr, conf); err != nil {
+		return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
+	}
+
 	//transformation #12
 	conf.EnvVariables[keyStreams] = string(mustMarshalJSON(conf.Source))
 	conf.EnvVariables[keyFlinkParallelism] = fmt.Sprint(conf.Replicas)
@@ -97,6 +103,9 @@ func (dd *daggerDriver) planChange(exr module.ExpandedResource, act module.Actio
 		}
 
 		newConf.Source = mergeConsumerGroupId(curConf.Source, newConf.Source)
+		if err := applyStreamSecurity(exr, newConf); err != nil {
+			return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
+		}
 		newConf.EnvVariables[keyStreams] = string(mustMarshalJSON(newConf.Source))
 		newConf.EnvVariables[keyFlinkParallelism] = fmt.Sprint(newConf.Replicas)
 
@@ -185,6 +194,9 @@ func (dd *daggerDriver) planReset(exr module.ExpandedResource, act module.Action
 	curConf.ResetOffset = resetValue
 
 	curConf.Source = dd.consumerReset(context.Background(), *curConf, resetValue)
+	if err := applyStreamSecurity(exr, curConf); err != nil {
+		return nil, errors.ErrInvalid.WithMsgf("failed to resolve source streams").WithCausef("%s", err.Error())
+	}
 	curConf.EnvVariables[keyStreams] = string(mustMarshalJSON(curConf.Source))
 
 	curConf.ChartValues = &dd.conf.ChartValues

--- a/modules/dagger/kafka_security.go
+++ b/modules/dagger/kafka_security.go
@@ -253,24 +253,28 @@ func buildACLMounts(sources []Source, profiles map[string]*kafkamod.SecurityProf
 	return mounts
 }
 
-// applyStreamSecurity resolves each source's kafka dependency, injects the
+// applyStreamSecurity resolves each source's kafka security profile, injects the
 // SASL/SSL consumer config into STREAMS, and records the podTemplate ACL mounts
 // on conf. It is a no-op (leaves conf untouched) for daggers whose sources have
-// no kafka dependency or no security profile.
+// no security profile.
 func applyStreamSecurity(exr module.ExpandedResource, conf *Config) error {
 	profiles, err := resolveSourceStreams(exr, conf)
-	if err != nil {
+	if err != nil { 
 		return err
 	}
 	conf.ACLMounts = buildACLMounts(conf.Source, profiles, conf.Team)
 	return nil
 }
 
-// resolveSourceStreams looks up each source's kind=kafka dependency (keyed by
+// resolveSourceStreams resolves each source's kafka security profile (keyed by
 // SOURCE_KAFKA_NAME), populates bootstrap servers and the SASL/SSL consumer
 // config, and returns the resolved security profiles keyed by stream name.
-// Sources without a matching kafka dependency (or with a plaintext profile) are
-// left untouched — preserving byte-for-byte identical STREAMS for ODS daggers.
+//
+// The profile is resolved inline-first: conf.StreamSecurity (populated by Dex on
+// the product path) takes precedence; otherwise it falls back to the kafka
+// dependency Output (raw-Entropy path). Sources with neither a profile nor a
+// plaintext profile are left untouched — preserving byte-for-byte identical
+// STREAMS for ODS daggers.
 func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string]*kafkamod.SecurityProfile, error) {
 	profiles := map[string]*kafkamod.SecurityProfile{}
 
@@ -280,28 +284,34 @@ func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string
 			continue
 		}
 
-		dep, ok := exr.Dependencies[streamName]
-		if !ok || dep.Kind != kafkamod.Module.Kind {
+		// inline profile (Dex product path) wins over the kafka dependency.
+		security := conf.StreamSecurity[streamName]
+
+		// fall back to the kafka dependency (raw-Entropy path): it also carries
+		// the resolved broker URL for bootstrap servers.
+		if security == nil {
+			if dep, ok := exr.Dependencies[streamName]; ok && dep.Kind == kafkamod.Module.Kind {
+				var out kafkamod.Output
+				if err := json.Unmarshal(dep.Output, &out); err != nil {
+					return nil, fmt.Errorf("invalid kafka dependency output for stream %q: %w", streamName, err)
+				}
+
+				// bootstrap servers: explicit source value wins, else resolved URL.
+				if conf.Source[i].SourceKafkaConsumerConfigBootstrapServers == "" && out.URL != "" {
+					conf.Source[i].SourceKafkaConsumerConfigBootstrapServers = out.URL
+				}
+
+				security = out.Security
+			}
+		}
+
+		if !hasSecurityProfile(security) {
 			continue
 		}
 
-		var out kafkamod.Output
-		if err := json.Unmarshal(dep.Output, &out); err != nil {
-			return nil, fmt.Errorf("invalid kafka dependency output for stream %q: %w", streamName, err)
-		}
-
-		// bootstrap servers: explicit source value wins, else resolved URL.
-		if conf.Source[i].SourceKafkaConsumerConfigBootstrapServers == "" && out.URL != "" {
-			conf.Source[i].SourceKafkaConsumerConfigBootstrapServers = out.URL
-		}
-
-		if !hasSecurityProfile(out.Security) {
-			continue
-		}
-
-		profiles[streamName] = out.Security
+		profiles[streamName] = security
 		conf.Source[i].SourceKafkaConsumerAdditionalConfigurations =
-			buildAdditionalConfigurations(streamName, out.Security, conf.Team)
+			buildAdditionalConfigurations(streamName, security, conf.Team)
 	}
 
 	return profiles, nil

--- a/modules/dagger/kafka_security.go
+++ b/modules/dagger/kafka_security.go
@@ -1,0 +1,308 @@
+package dagger
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/goto/entropy/core/module"
+	kafkamod "github.com/goto/entropy/modules/kafka"
+)
+
+// SASL/SSL consumer config keys injected into
+// SOURCE_KAFKA_CONSUMER_ADDITIONAL_CONFIGURATIONS.
+const (
+	keyConsumerSecurityProtocol             = "SOURCE_KAFKA_CONSUMER_CONFIG_SECURITY_PROTOCOL"
+	keyConsumerSaslMechanism                = "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_MECHANISM"
+	keyConsumerSaslJaasConfig               = "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_JAAS_CONFIG"
+	keyConsumerSaslLoginCallbackHandler     = "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_LOGIN_CALLBACK_HANDLER_CLASS"
+	keyConsumerSSLProtocol                  = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_PROTOCOL"
+	keyConsumerSSLTruststoreType            = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_TYPE"
+	keyConsumerSSLTruststoreLocation        = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_LOCATION"
+	keyConsumerSSLTruststorePassword        = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_PASSWORD"
+	keyConsumerSSLTruststorePasswordDetails = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_PASSWORD_DETAILS"
+	keyConsumerSSLCertSecret                = "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_CERT_SECRET"
+	keyConsumerConfigProviders              = "SOURCE_KAFKA_CONSUMER_CONFIG_CONFIG_PROVIDERS"
+	keyConsumerConfigProvidersLiteralClass  = "SOURCE_KAFKA_CONSUMER_CONFIG_CONFIG_PROVIDERS_LITERALFILE_CLASS"
+)
+
+// GTF Kafka security constants (mirrors odin app/dagger/constants.js).
+const (
+	oauthSaslLoginCallbackHandlerClass = "io.gtflabs.kafka.security.oauthbearer.kubernetes.PodLoginCallbackHandler"
+	oauthConsumerSaslJaasConfig        = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"
+	scramLoginModule                   = "org.apache.kafka.common.security.scram.ScramLoginModule"
+	plainLoginModule                   = "org.apache.kafka.common.security.plain.PlainLoginModule"
+	literalFileConfigProviderClass     = "com.gtf.dagger.kafka.configproviders.LiteralFileConfigProvider"
+	literalFileConfigProviderName      = "literalfile"
+)
+
+const (
+	securityProtocolSASLSSL       = "SASL_SSL"
+	securityProtocolSASLPlaintext = "SASL_PLAINTEXT"
+	securityProtocolSSL           = "SSL"
+	saslMechanismOauthbearer      = "OAUTHBEARER"
+	saslMechanismPlain            = "PLAIN"
+	saslMechanismScram            = "SCRAM-SHA-512"
+	truststoreTypePKCS12          = "PKCS12"
+)
+
+// mount path templates, kept consistent between the injected consumer config
+// (R3) and the podTemplate mounts (R4).
+const (
+	kafkaTokenVolumeName    = "kafka-token"
+	kafkaTokenMountPath     = "/var/run/secrets/kafka/serviceaccount"
+	certsMountPathFmt       = "/var/secrets/%s/certs"
+	passwordsMountPathFmt   = "/var/secrets/%s/passwords"
+	credentialsMountPathFmt = "/var/secrets/%s/credentials"
+)
+
+var invalidVolumeNameChars = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+func isOauthbearerStream(sp *kafkamod.SecurityProfile) bool {
+	return sp != nil &&
+		sp.SecurityProtocol == securityProtocolSASLSSL &&
+		sp.SaslMechanism == saslMechanismOauthbearer &&
+		sp.SSLCertSecret != "" &&
+		sp.SSLTruststorePasswordDetails != nil
+}
+
+func isPlainOrScramStream(sp *kafkamod.SecurityProfile) bool {
+	if sp == nil {
+		return false
+	}
+	protoOK := sp.SecurityProtocol == securityProtocolSASLPlaintext || sp.SecurityProtocol == securityProtocolSASLSSL
+	mechOK := sp.SaslMechanism == saslMechanismPlain || sp.SaslMechanism == saslMechanismScram
+	return protoOK && mechOK
+}
+
+func isTLSStream(sp *kafkamod.SecurityProfile) bool {
+	return sp != nil && sp.SecurityProtocol == securityProtocolSSL
+}
+
+// hasSecurityProfile reports whether the profile requires any SASL/SSL wiring.
+func hasSecurityProfile(sp *kafkamod.SecurityProfile) bool {
+	return sp != nil && sp.SecurityProtocol != "" && !strings.EqualFold(sp.SecurityProtocol, "PLAINTEXT")
+}
+
+func truststoreExtension(truststoreType string) string {
+	if strings.EqualFold(truststoreType, truststoreTypePKCS12) {
+		return "p12"
+	}
+	return "jks"
+}
+
+// buildAdditionalConfigurations builds the SOURCE_KAFKA_CONSUMER_ADDITIONAL_CONFIGURATIONS
+// map for a source stream, branching on its security profile. streamName is the
+// stable per-stream directory name used both here and in the podTemplate mounts.
+// Returns nil for plaintext streams so STREAMS stays unchanged.
+func buildAdditionalConfigurations(streamName string, sp *kafkamod.SecurityProfile, team string) map[string]interface{} {
+	if !hasSecurityProfile(sp) {
+		return nil
+	}
+
+	cfg := map[string]interface{}{}
+	cfg[keyConsumerSecurityProtocol] = sp.SecurityProtocol
+	if sp.SaslMechanism != "" {
+		cfg[keyConsumerSaslMechanism] = sp.SaslMechanism
+	}
+
+	// SSL material is shared by the TLS and OAUTHBEARER paths.
+	if isTLSStream(sp) || isOauthbearerStream(sp) {
+		if sp.SSLProtocol != "" {
+			cfg[keyConsumerSSLProtocol] = sp.SSLProtocol
+		}
+		if sp.SSLTruststoreType != "" {
+			cfg[keyConsumerSSLTruststoreType] = sp.SSLTruststoreType
+		}
+		if sp.SSLCertSecret != "" {
+			cfg[keyConsumerSSLCertSecret] = sp.SSLCertSecret
+		}
+		if sp.SSLTruststorePasswordDetails != nil {
+			// map (not struct) so JSON key order is deterministic and matches
+			// the reference fixture ({key, secretName}).
+			cfg[keyConsumerSSLTruststorePasswordDetails] = map[string]string{
+				"key":        sp.SSLTruststorePasswordDetails.Key,
+				"secretName": sp.SSLTruststorePasswordDetails.SecretName,
+			}
+		}
+	}
+
+	if isOauthbearerStream(sp) {
+		cfg[keyConsumerSaslLoginCallbackHandler] = oauthSaslLoginCallbackHandlerClass
+		cfg[keyConsumerSaslJaasConfig] = oauthConsumerSaslJaasConfig
+		cfg[keyConsumerSSLTruststoreLocation] = fmt.Sprintf(
+			"/var/secrets/%s/certs/truststore.%s", streamName, truststoreExtension(sp.SSLTruststoreType))
+		if sp.SSLTruststorePasswordDetails != nil {
+			cfg[keyConsumerSSLTruststorePassword] = fmt.Sprintf(
+				"${literalfile:/var/secrets/%s/passwords/%s:literal-value}",
+				streamName, sp.SSLTruststorePasswordDetails.Key)
+		}
+		cfg[keyConsumerConfigProviders] = literalFileConfigProviderName
+		cfg[keyConsumerConfigProvidersLiteralClass] = literalFileConfigProviderClass
+	}
+
+	if isPlainOrScramStream(sp) {
+		cfg[keyConsumerSaslJaasConfig] = buildSASLJaasConfig(streamName, sp, team)
+		// credentials are referenced via the literalfile provider (never inlined).
+		if _, ok := sp.ACLs[team]; ok {
+			cfg[keyConsumerConfigProviders] = literalFileConfigProviderName
+			cfg[keyConsumerConfigProvidersLiteralClass] = literalFileConfigProviderClass
+		}
+	}
+
+	return cfg
+}
+
+// buildSASLJaasConfig builds the JAAS config string for PLAIN/SCRAM mechanisms.
+// Credentials are referenced through the literalfile config provider pointing
+func buildSASLJaasConfig(streamName string, sp *kafkamod.SecurityProfile, team string) string {
+	loginModule := scramLoginModule
+	if sp.SaslMechanism == saslMechanismPlain {
+		loginModule = plainLoginModule
+	}
+
+	cred, ok := sp.ACLs[team]
+	if !ok || cred.SecretName == "" {
+		return fmt.Sprintf("%s required;", loginModule)
+	}
+
+	userRef := fmt.Sprintf("${literalfile:/var/secrets/%s/credentials/%s:literal-value}", streamName, cred.UsernameKey)
+	passRef := fmt.Sprintf("${literalfile:/var/secrets/%s/credentials/%s:literal-value}", streamName, cred.PasswordKey)
+	return fmt.Sprintf("%s required username=%q password=%q;", loginModule, userRef, passRef)
+}
+
+// sanitizeVolumeName renders a k8s-safe (<=63 char, lowercase alnum/dash) volume name.
+func sanitizeVolumeName(name string) string {
+	sanitized := invalidVolumeNameChars.ReplaceAllString(name, "-")
+	sanitized = strings.ToLower(strings.Trim(sanitized, "-"))
+	if len(sanitized) > 63 {
+		sanitized = strings.Trim(sanitized[:63], "-")
+	}
+	return sanitized
+}
+
+// buildACLMounts derives the podTemplate volume mounts for the given sources'
+// security profiles. Returns nil when no source needs ACL mounts so the
+// podTemplate is unchanged for plaintext daggers.
+func buildACLMounts(sources []Source, profiles map[string]*kafkamod.SecurityProfile, team string) []ACLMount {
+	var mounts []ACLMount
+
+	for _, src := range sources {
+		streamName := src.SourceKafkaName
+		sp := profiles[streamName]
+		if !hasSecurityProfile(sp) {
+			continue
+		}
+
+		if isOauthbearerStream(sp) {
+			mounts = append(mounts, ACLMount{
+				Name:       sanitizeVolumeName(streamName + "-" + sp.SSLCertSecret),
+				MountPath:  fmt.Sprintf(certsMountPathFmt, streamName),
+				SecretName: sp.SSLCertSecret,
+				Type:       "secret",
+			})
+			mounts = append(mounts, ACLMount{
+				Name:       sanitizeVolumeName(streamName + "-" + sp.SSLTruststorePasswordDetails.SecretName),
+				MountPath:  fmt.Sprintf(passwordsMountPathFmt, streamName),
+				SecretName: sp.SSLTruststorePasswordDetails.SecretName,
+				Type:       "secret",
+			})
+		} else if isTLSStream(sp) && sp.SSLCertSecret != "" {
+			mounts = append(mounts, ACLMount{
+				Name:       sanitizeVolumeName(streamName + "-" + sp.SSLCertSecret),
+				MountPath:  fmt.Sprintf(certsMountPathFmt, streamName),
+				SecretName: sp.SSLCertSecret,
+				Type:       "secret",
+			})
+			if sp.SSLTruststorePasswordDetails != nil && sp.SSLTruststorePasswordDetails.SecretName != "" {
+				mounts = append(mounts, ACLMount{
+					Name:       sanitizeVolumeName(streamName + "-" + sp.SSLTruststorePasswordDetails.SecretName),
+					MountPath:  fmt.Sprintf(passwordsMountPathFmt, streamName),
+					SecretName: sp.SSLTruststorePasswordDetails.SecretName,
+					Type:       "secret",
+				})
+			}
+		}
+
+		// PLAIN/SCRAM: mount the team's referenced credential secret so the
+		// literalfile provider can read username/password without inlining them.
+		if isPlainOrScramStream(sp) {
+			if cred, ok := sp.ACLs[team]; ok && cred.SecretName != "" {
+				mounts = append(mounts, ACLMount{
+					Name:       sanitizeVolumeName(streamName + "-" + cred.SecretName),
+					MountPath:  fmt.Sprintf(credentialsMountPathFmt, streamName),
+					SecretName: cred.SecretName,
+					Type:       "secret",
+				})
+			}
+		}
+	}
+
+	if len(mounts) == 0 {
+		return nil
+	}
+
+	// single shared projected kafka service-account token.
+	mounts = append(mounts, ACLMount{
+		Name:      kafkaTokenVolumeName,
+		MountPath: kafkaTokenMountPath,
+		Type:      "projected",
+	})
+
+	return mounts
+}
+
+// applyStreamSecurity resolves each source's kafka dependency, injects the
+// SASL/SSL consumer config into STREAMS, and records the podTemplate ACL mounts
+// on conf. It is a no-op (leaves conf untouched) for daggers whose sources have
+// no kafka dependency or no security profile.
+func applyStreamSecurity(exr module.ExpandedResource, conf *Config) error {
+	profiles, err := resolveSourceStreams(exr, conf)
+	if err != nil {
+		return err
+	}
+	conf.ACLMounts = buildACLMounts(conf.Source, profiles, conf.Team)
+	return nil
+}
+
+// resolveSourceStreams looks up each source's kind=kafka dependency (keyed by
+// SOURCE_KAFKA_NAME), populates bootstrap servers and the SASL/SSL consumer
+// config, and returns the resolved security profiles keyed by stream name.
+// Sources without a matching kafka dependency (or with a plaintext profile) are
+// left untouched — preserving byte-for-byte identical STREAMS for ODS daggers.
+func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string]*kafkamod.SecurityProfile, error) {
+	profiles := map[string]*kafkamod.SecurityProfile{}
+
+	for i := range conf.Source {
+		streamName := conf.Source[i].SourceKafkaName
+		if streamName == "" {
+			continue
+		}
+
+		dep, ok := exr.Dependencies[streamName]
+		if !ok || dep.Kind != kafkamod.Module.Kind {
+			continue
+		}
+
+		var out kafkamod.Output
+		if err := json.Unmarshal(dep.Output, &out); err != nil {
+			return nil, fmt.Errorf("invalid kafka dependency output for stream %q: %w", streamName, err)
+		}
+
+		// bootstrap servers: explicit source value wins, else resolved URL.
+		if conf.Source[i].SourceKafkaConsumerConfigBootstrapServers == "" && out.URL != "" {
+			conf.Source[i].SourceKafkaConsumerConfigBootstrapServers = out.URL
+		}
+
+		if !hasSecurityProfile(out.Security) {
+			continue
+		}
+
+		profiles[streamName] = out.Security
+		conf.Source[i].SourceKafkaConsumerAdditionalConfigurations =
+			buildAdditionalConfigurations(streamName, out.Security, conf.Team)
+	}
+
+	return profiles, nil
+}

--- a/modules/dagger/kafka_security.go
+++ b/modules/dagger/kafka_security.go
@@ -1,12 +1,14 @@
 package dagger
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/goto/entropy/core/module"
+	"github.com/goto/entropy/core/resource"
 	kafkamod "github.com/goto/entropy/modules/kafka"
 )
 
@@ -254,12 +256,12 @@ func buildACLMounts(sources []Source, profiles map[string]*kafkamod.SecurityProf
 }
 
 // applyStreamSecurity resolves each source's kafka security profile, injects the
-// SASL/SSL consumer config into STREAMS, and records the podTemplate ACL mounts
-// on conf. It is a no-op (leaves conf untouched) for daggers whose sources have
-// no security profile.
-func applyStreamSecurity(exr module.ExpandedResource, conf *Config) error {
-	profiles, err := resolveSourceStreams(exr, conf)
-	if err != nil { 
+// SASL/SSL consumer config into the source, and records the podTemplate ACL
+// mounts on conf. It is a no-op (leaves conf untouched) for daggers whose
+// sources have no security profile.
+func (dd *daggerDriver) applyStreamSecurity(ctx context.Context, exr module.ExpandedResource, conf *Config) error {
+	profiles, err := dd.resolveSourceStreams(ctx, exr, conf)
+	if err != nil {
 		return err
 	}
 	conf.ACLMounts = buildACLMounts(conf.Source, profiles, conf.Team)
@@ -267,15 +269,16 @@ func applyStreamSecurity(exr module.ExpandedResource, conf *Config) error {
 }
 
 // resolveSourceStreams resolves each source's kafka security profile (keyed by
-// SOURCE_KAFKA_NAME), populates bootstrap servers and the SASL/SSL consumer
-// config, and returns the resolved security profiles keyed by stream name.
+// SOURCE_KAFKA_NAME), populates the SASL/SSL consumer config, and returns the
+// resolved profiles keyed by stream name.
 //
-// The profile is resolved inline-first: conf.StreamSecurity (populated by Dex on
-// the product path) takes precedence; otherwise it falls back to the kafka
-// dependency Output (raw-Entropy path). Sources with neither a profile nor a
-// plaintext profile are left untouched — preserving byte-for-byte identical
-// STREAMS for ODS daggers.
-func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string]*kafkamod.SecurityProfile, error) {
+// Resolution order per source: an inline conf.StreamSecurity entry, then a
+// declared kafka dependency (raw-Entropy path), then — when the source carries
+// the SOURCE_KAFKA_SECURITY_ENABLED flag (the Dex product path) — the kafka
+// resource fetched internally by URN via dd.getResource, with no dependency.
+// Sources with none of these (plaintext) are left untouched, preserving
+// byte-for-byte identical STREAMS for ODS daggers.
+func (dd *daggerDriver) resolveSourceStreams(ctx context.Context, exr module.ExpandedResource, conf *Config) (map[string]*kafkamod.SecurityProfile, error) {
 	profiles := map[string]*kafkamod.SecurityProfile{}
 
 	for i := range conf.Source {
@@ -284,25 +287,34 @@ func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string
 			continue
 		}
 
-		// inline profile (Dex product path) wins over the kafka dependency.
+		// 1. inline profile, if Dex ever sends one.
 		security := conf.StreamSecurity[streamName]
 
-		// fall back to the kafka dependency (raw-Entropy path): it also carries
-		// the resolved broker URL for bootstrap servers.
+		// 2. declared kafka dependency (raw-Entropy path): also carries the URL.
 		if security == nil {
 			if dep, ok := exr.Dependencies[streamName]; ok && dep.Kind == kafkamod.Module.Kind {
 				var out kafkamod.Output
 				if err := json.Unmarshal(dep.Output, &out); err != nil {
 					return nil, fmt.Errorf("invalid kafka dependency output for stream %q: %w", streamName, err)
 				}
-
-				// bootstrap servers: explicit source value wins, else resolved URL.
 				if conf.Source[i].SourceKafkaConsumerConfigBootstrapServers == "" && out.URL != "" {
 					conf.Source[i].SourceKafkaConsumerConfigBootstrapServers = out.URL
 				}
-
 				security = out.Security
 			}
+		}
+
+		// 3. flag set (Dex product path): fetch the kafka resource internally by
+		// URN and read its security profile — no dependency declared.
+		if security == nil && conf.Source[i].SourceKafkaSecurityEnabled {
+			out, err := dd.fetchKafkaOutput(ctx, exr.Resource.Project, streamName)
+			if err != nil {
+				return nil, err
+			}
+			if conf.Source[i].SourceKafkaConsumerConfigBootstrapServers == "" && out.URL != "" {
+				conf.Source[i].SourceKafkaConsumerConfigBootstrapServers = out.URL
+			}
+			security = out.Security
 		}
 
 		if !hasSecurityProfile(security) {
@@ -315,4 +327,34 @@ func resolveSourceStreams(exr module.ExpandedResource, conf *Config) (map[string
 	}
 
 	return profiles, nil
+}
+
+// fetchKafkaOutput fetches the kafka stream's resource by URN and decodes its
+// Output (url + security profile). SOURCE_KAFKA_NAME is the kafka resource name.
+func (dd *daggerDriver) fetchKafkaOutput(ctx context.Context, project, streamName string) (kafkamod.Output, error) {
+	var out kafkamod.Output
+	if dd.getResource == nil {
+		return out, fmt.Errorf("cannot resolve kafka stream %q: resource getter not configured", streamName)
+	}
+
+	urn := resource.GenerateURN(kafkamod.Module.Kind, project, streamName)
+	res, err := dd.getResource(ctx, urn)
+	if err != nil {
+		return out, fmt.Errorf("failed to fetch kafka stream %q (%s): %w", streamName, urn, err)
+	}
+	if err := json.Unmarshal(res.State.Output, &out); err != nil {
+		return out, fmt.Errorf("invalid kafka output for stream %q: %w", streamName, err)
+	}
+	return out, nil
+}
+
+// streamsJSON marshals sources for the STREAMS env var, stripping the transient
+// SOURCE_KAFKA_SECURITY_ENABLED flag so it never leaks into the running job.
+func streamsJSON(sources []Source) string {
+	sanitized := make([]Source, len(sources))
+	copy(sanitized, sources)
+	for i := range sanitized {
+		sanitized[i].SourceKafkaSecurityEnabled = false
+	}
+	return string(mustMarshalJSON(sanitized))
 }

--- a/modules/dagger/kafka_security_test.go
+++ b/modules/dagger/kafka_security_test.go
@@ -122,7 +122,47 @@ func TestResolveSourceStreams_PopulatesBootstrapAndConfig(t *testing.T) {
 	assert.Contains(t, profiles, pocStream)
 }
 
-// R2: an explicit bootstrap servers value on the source is not overwritten.
+// Product (Dex) path: the security profile is inlined on conf.StreamSecurity
+// with NO kafka dependency present, and the ACL wiring still fires.
+func TestResolveSourceStreams_InlineProfile_NoDependency(t *testing.T) {
+	conf := &Config{
+		Team:   "team-x",
+		Source: []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}},
+		StreamSecurity: map[string]*kafkamod.SecurityProfile{
+			pocStream: oauthbearerProfile(),
+		},
+	}
+
+	profiles, err := resolveSourceStreams(module.ExpandedResource{}, conf)
+	require.NoError(t, err)
+
+	require.Contains(t, profiles, pocStream)
+	assert.NotNil(t, conf.Source[0].SourceKafkaConsumerAdditionalConfigurations)
+	assert.Equal(t,
+		"SASL_SSL",
+		conf.Source[0].SourceKafkaConsumerAdditionalConfigurations[keyConsumerSecurityProtocol])
+
+	mounts := buildACLMounts(conf.Source, profiles, conf.Team)
+	require.Len(t, mounts, 3)
+}
+
+// a full plaintext dagger (no stream_security, no kafka dependency) produces
+// no additional configs, no mounts, and no taskmanager SA — STREAMS/podTemplate
+// unchanged.
+func TestApplyStreamSecurity_PlaintextDagger_NoWiring(t *testing.T) {
+	conf := &Config{
+		Team:   "team-x",
+		Source: []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}},
+	}
+
+	require.NoError(t, applyStreamSecurity(module.ExpandedResource{}, conf))
+
+	assert.Nil(t, conf.Source[0].SourceKafkaConsumerAdditionalConfigurations)
+	assert.Nil(t, conf.ACLMounts)
+	assert.Empty(t, conf.TaskManagerServiceAccount)
+}
+
+// an explicit bootstrap servers value on the source is not overwritten.
 func TestResolveSourceStreams_KeepsExplicitBootstrap(t *testing.T) {
 	out := kafkamod.Output{URL: "resolved:9098"}
 	outJSON, err := json.Marshal(out)

--- a/modules/dagger/kafka_security_test.go
+++ b/modules/dagger/kafka_security_test.go
@@ -1,6 +1,7 @@
 package dagger
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/goto/entropy/core/module"
+	"github.com/goto/entropy/core/resource"
 	kafkamod "github.com/goto/entropy/modules/kafka"
 )
 
@@ -114,7 +116,7 @@ func TestResolveSourceStreams_PopulatesBootstrapAndConfig(t *testing.T) {
 		Source: []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}},
 	}
 
-	profiles, err := resolveSourceStreams(exr, conf)
+	profiles, err := (&daggerDriver{}).resolveSourceStreams(context.Background(), exr, conf)
 	require.NoError(t, err)
 
 	assert.Equal(t, "broker-1:9098,broker-2:9098", conf.Source[0].SourceKafkaConsumerConfigBootstrapServers)
@@ -133,7 +135,7 @@ func TestResolveSourceStreams_InlineProfile_NoDependency(t *testing.T) {
 		},
 	}
 
-	profiles, err := resolveSourceStreams(module.ExpandedResource{}, conf)
+	profiles, err := (&daggerDriver{}).resolveSourceStreams(context.Background(), module.ExpandedResource{}, conf)
 	require.NoError(t, err)
 
 	require.Contains(t, profiles, pocStream)
@@ -146,6 +148,40 @@ func TestResolveSourceStreams_InlineProfile_NoDependency(t *testing.T) {
 	require.Len(t, mounts, 3)
 }
 
+func TestResolveSourceStreams_FlagFetchesInternally(t *testing.T) {
+	out := kafkamod.Output{URL: "11.0.0.1:9098", Security: oauthbearerProfile()}
+	outJSON, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	var gotURN string
+	dd := &daggerDriver{
+		getResource: func(_ context.Context, urn string) (*resource.Resource, error) {
+			gotURN = urn
+			return &resource.Resource{State: resource.State{Output: outJSON}}, nil
+		},
+	}
+
+	exr := module.ExpandedResource{Resource: resource.Resource{Project: "al-dp-id-s"}}
+	conf := &Config{
+		Team: "team-x",
+		Source: []Source{{SourceKafka: SourceKafka{
+			SourceKafkaName:            pocStream,
+			SourceKafkaSecurityEnabled: true,
+		}}},
+	}
+
+	profiles, err := dd.resolveSourceStreams(context.Background(), exr, conf)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.GenerateURN(kafkamod.Module.Kind, "al-dp-id-s", pocStream), gotURN)
+	require.Contains(t, profiles, pocStream)
+	assert.Equal(t, "11.0.0.1:9098", conf.Source[0].SourceKafkaConsumerConfigBootstrapServers)
+	assert.NotNil(t, conf.Source[0].SourceKafkaConsumerAdditionalConfigurations)
+
+	// the flag must be stripped from the STREAMS env var.
+	assert.NotContains(t, streamsJSON(conf.Source), "SOURCE_KAFKA_SECURITY_ENABLED")
+}
+
 // a full plaintext dagger (no stream_security, no kafka dependency) produces
 // no additional configs, no mounts, and no taskmanager SA — STREAMS/podTemplate
 // unchanged.
@@ -155,7 +191,7 @@ func TestApplyStreamSecurity_PlaintextDagger_NoWiring(t *testing.T) {
 		Source: []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}},
 	}
 
-	require.NoError(t, applyStreamSecurity(module.ExpandedResource{}, conf))
+	require.NoError(t, (&daggerDriver{}).applyStreamSecurity(context.Background(), module.ExpandedResource{}, conf))
 
 	assert.Nil(t, conf.Source[0].SourceKafkaConsumerAdditionalConfigurations)
 	assert.Nil(t, conf.ACLMounts)
@@ -180,7 +216,7 @@ func TestResolveSourceStreams_KeepsExplicitBootstrap(t *testing.T) {
 		}}},
 	}
 
-	_, err = resolveSourceStreams(exr, conf)
+	_, err = (&daggerDriver{}).resolveSourceStreams(context.Background(), exr, conf)
 	require.NoError(t, err)
 	assert.Equal(t, "explicit:9092", conf.Source[0].SourceKafkaConsumerConfigBootstrapServers)
 }

--- a/modules/dagger/kafka_security_test.go
+++ b/modules/dagger/kafka_security_test.go
@@ -1,0 +1,166 @@
+package dagger
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goto/entropy/core/module"
+	kafkamod "github.com/goto/entropy/modules/kafka"
+)
+
+const pocStream = "al-gp-id-s-central-kf"
+
+func oauthbearerProfile() *kafkamod.SecurityProfile {
+	return &kafkamod.SecurityProfile{
+		SecurityProtocol:  "SASL_SSL",
+		SaslMechanism:     "OAUTHBEARER",
+		SSLProtocol:       "SSL",
+		SSLTruststoreType: "PKCS12",
+		SSLCertSecret:     "kafka-central-cert",
+		SSLTruststorePasswordDetails: &kafkamod.SecretKeyRef{
+			SecretName: "scp-kafka-ssl-secrets",
+			Key:        "truststore_password",
+		},
+	}
+}
+
+// Acceptance criterion #1: the injected additional-configurations block matches
+// the reference fixture (compared semantically, order-independent).
+func TestBuildAdditionalConfigurations_OAUTHBEARER_MatchesFixture(t *testing.T) {
+	got := buildAdditionalConfigurations(pocStream, oauthbearerProfile(), "team-x")
+
+	fixture := `{
+      "SOURCE_KAFKA_CONSUMER_CONFIG_CONFIG_PROVIDERS": "literalfile",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_CONFIG_PROVIDERS_LITERALFILE_CLASS": "com.gtf.dagger.kafka.configproviders.LiteralFileConfigProvider",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_JAAS_CONFIG": "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_LOGIN_CALLBACK_HANDLER_CLASS": "io.gtflabs.kafka.security.oauthbearer.kubernetes.PodLoginCallbackHandler",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SASL_MECHANISM": "OAUTHBEARER",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SECURITY_PROTOCOL": "SASL_SSL",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_CERT_SECRET": "kafka-central-cert",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_PROTOCOL": "SSL",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_LOCATION": "/var/secrets/al-gp-id-s-central-kf/certs/truststore.p12",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_PASSWORD": "${literalfile:/var/secrets/al-gp-id-s-central-kf/passwords/truststore_password:literal-value}",
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_PASSWORD_DETAILS": { "key": "truststore_password", "secretName": "scp-kafka-ssl-secrets" },
+      "SOURCE_KAFKA_CONSUMER_CONFIG_SSL_TRUSTSTORE_TYPE": "PKCS12"
+    }`
+
+	var want map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(fixture), &want))
+
+	// round-trip got through JSON so nested types compare equal to the fixture.
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	var gotNormalized map[string]interface{}
+	require.NoError(t, json.Unmarshal(gotJSON, &gotNormalized))
+
+	assert.Equal(t, want, gotNormalized)
+}
+
+// Acceptance criterion #2: the podTemplate mounts match the reference fixture.
+func TestBuildACLMounts_OAUTHBEARER_MatchesFixture(t *testing.T) {
+	sources := []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}}
+	profiles := map[string]*kafkamod.SecurityProfile{pocStream: oauthbearerProfile()}
+
+	mounts := buildACLMounts(sources, profiles, "team-x")
+
+	require.Len(t, mounts, 3)
+	assert.Equal(t, ACLMount{
+		Name:       "al-gp-id-s-central-kf-kafka-central-cert",
+		MountPath:  "/var/secrets/al-gp-id-s-central-kf/certs",
+		SecretName: "kafka-central-cert",
+		Type:       "secret",
+	}, mounts[0])
+	assert.Equal(t, ACLMount{
+		Name:       "al-gp-id-s-central-kf-scp-kafka-ssl-secrets",
+		MountPath:  "/var/secrets/al-gp-id-s-central-kf/passwords",
+		SecretName: "scp-kafka-ssl-secrets",
+		Type:       "secret",
+	}, mounts[1])
+	assert.Equal(t, ACLMount{
+		Name:      "kafka-token",
+		MountPath: "/var/run/secrets/kafka/serviceaccount",
+		Type:      "projected",
+	}, mounts[2])
+}
+
+// Acceptance criterion #5 / R6: a plaintext source produces no additional config
+// and no mounts (byte-for-byte unchanged STREAMS/podTemplate).
+func TestPlaintextSource_NoSecurityWiring(t *testing.T) {
+	assert.Nil(t, buildAdditionalConfigurations(pocStream, nil, "team-x"))
+	assert.Nil(t, buildAdditionalConfigurations(pocStream, &kafkamod.SecurityProfile{}, "team-x"))
+	assert.Nil(t, buildAdditionalConfigurations(pocStream, &kafkamod.SecurityProfile{SecurityProtocol: "PLAINTEXT"}, "team-x"))
+
+	sources := []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}}
+	assert.Nil(t, buildACLMounts(sources, map[string]*kafkamod.SecurityProfile{}, "team-x"))
+}
+
+// R2: bootstrap servers are populated from the resolved stream URL when not set,
+// and the additional configuration is attached to the source.
+func TestResolveSourceStreams_PopulatesBootstrapAndConfig(t *testing.T) {
+	out := kafkamod.Output{URL: "broker-1:9098,broker-2:9098", Security: oauthbearerProfile()}
+	outJSON, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	exr := module.ExpandedResource{
+		Dependencies: map[string]module.ResolvedDependency{
+			pocStream: {Kind: kafkamod.Module.Kind, Output: outJSON},
+		},
+	}
+	conf := &Config{
+		Team:   "team-x",
+		Source: []Source{{SourceKafka: SourceKafka{SourceKafkaName: pocStream}}},
+	}
+
+	profiles, err := resolveSourceStreams(exr, conf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "broker-1:9098,broker-2:9098", conf.Source[0].SourceKafkaConsumerConfigBootstrapServers)
+	assert.NotNil(t, conf.Source[0].SourceKafkaConsumerAdditionalConfigurations)
+	assert.Contains(t, profiles, pocStream)
+}
+
+// R2: an explicit bootstrap servers value on the source is not overwritten.
+func TestResolveSourceStreams_KeepsExplicitBootstrap(t *testing.T) {
+	out := kafkamod.Output{URL: "resolved:9098"}
+	outJSON, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	exr := module.ExpandedResource{
+		Dependencies: map[string]module.ResolvedDependency{
+			pocStream: {Kind: kafkamod.Module.Kind, Output: outJSON},
+		},
+	}
+	conf := &Config{
+		Source: []Source{{SourceKafka: SourceKafka{
+			SourceKafkaName: pocStream,
+			SourceKafkaConsumerConfigBootstrapServers: "explicit:9092",
+		}}},
+	}
+
+	_, err = resolveSourceStreams(exr, conf)
+	require.NoError(t, err)
+	assert.Equal(t, "explicit:9092", conf.Source[0].SourceKafkaConsumerConfigBootstrapServers)
+}
+
+// PLAIN/SCRAM: JAAS config references credentials through the literalfile
+// provider — never inlining the secret values.
+func TestBuildAdditionalConfigurations_PlainScram_NoInlinedSecrets(t *testing.T) {
+	sp := &kafkamod.SecurityProfile{
+		SecurityProtocol: "SASL_SSL",
+		SaslMechanism:    "SCRAM-SHA-512",
+		ACLs: map[string]kafkamod.ACLCredentialRef{
+			"team-x": {SecretName: "team-x-creds", UsernameKey: "username", PasswordKey: "password"},
+		},
+	}
+
+	got := buildAdditionalConfigurations(pocStream, sp, "team-x")
+	jaas, _ := got[keyConsumerSaslJaasConfig].(string)
+
+	assert.Contains(t, jaas, "ScramLoginModule")
+	assert.Contains(t, jaas, "${literalfile:/var/secrets/al-gp-id-s-central-kf/credentials/username:literal-value}")
+	assert.Contains(t, jaas, "${literalfile:/var/secrets/al-gp-id-s-central-kf/credentials/password:literal-value}")
+	assert.Equal(t, "literalfile", got[keyConsumerConfigProviders])
+}

--- a/modules/dagger/module.go
+++ b/modules/dagger/module.go
@@ -29,96 +29,102 @@ type FlinkCRDStatus struct {
 	ReconciliationStatus       string `json:"reconciliationStatus"`
 }
 
-var Module = module.Descriptor{
-	Kind: "dagger",
-	Dependencies: map[string]string{
-		keyFlinkDependency: flink.Module.Kind,
-	},
-	Actions: []module.ActionDesc{
-		{
-			Name:        module.CreateAction,
-			Description: "Creates a new dagger",
+// Module builds the dagger module descriptor. getResource lets the driver fetch
+// a referenced kafka stream's resource internally (by URN) to resolve its
+// security profile, without declaring it as a dependency.
+func Module(getResource ResourceGetter) module.Descriptor {
+	return module.Descriptor{
+		Kind: "dagger",
+		Dependencies: map[string]string{
+			keyFlinkDependency: flink.Module.Kind,
 		},
-		{
-			Name:        module.UpdateAction,
-			Description: "Updates an existing dagger",
+		Actions: []module.ActionDesc{
+			{
+				Name:        module.CreateAction,
+				Description: "Creates a new dagger",
+			},
+			{
+				Name:        module.UpdateAction,
+				Description: "Updates an existing dagger",
+			},
+			{
+				Name:        StopAction,
+				Description: "Suspends a running dagger",
+			},
+			{
+				Name:        StartAction,
+				Description: "Starts a suspended dagger",
+			},
+			{
+				Name:        ResetAction,
+				Description: "Resets the offset of a dagger",
+			},
 		},
-		{
-			Name:        StopAction,
-			Description: "Suspends a running dagger",
-		},
-		{
-			Name:        StartAction,
-			Description: "Starts a suspended dagger",
-		},
-		{
-			Name:        ResetAction,
-			Description: "Resets the offset of a dagger",
-		},
-	},
-	DriverFactory: func(confJSON json.RawMessage) (module.Driver, error) {
-		conf := defaultDriverConf // clone the default value
-		if err := json.Unmarshal(confJSON, &conf); err != nil {
-			return nil, err
-		} else if err := validator.TaggedStruct(conf); err != nil {
-			return nil, err
-		}
+		DriverFactory: func(confJSON json.RawMessage) (module.Driver, error) {
+			conf := defaultDriverConf // clone the default value
+			if err := json.Unmarshal(confJSON, &conf); err != nil {
+				return nil, err
+			} else if err := validator.TaggedStruct(conf); err != nil {
+				return nil, err
+			}
 
-		return &daggerDriver{
-			conf:    conf,
-			timeNow: time.Now,
-			kubeDeploy: func(_ context.Context, isCreate bool, kubeConf kube.Config, hc helm.ReleaseConfig) error {
-				canUpdate := func(rel *release.Release) bool {
-					curLabels, ok := rel.Config[labelsConfKey].(map[string]any)
-					if !ok {
-						return false
+			return &daggerDriver{
+				conf:    conf,
+				timeNow: time.Now,
+				kubeDeploy: func(_ context.Context, isCreate bool, kubeConf kube.Config, hc helm.ReleaseConfig) error {
+					canUpdate := func(rel *release.Release) bool {
+						curLabels, ok := rel.Config[labelsConfKey].(map[string]any)
+						if !ok {
+							return false
+						}
+						newLabels, ok := hc.Values[labelsConfKey].(map[string]string)
+						if !ok {
+							return false
+						}
+
+						isManagedByEntropy := curLabels[labelOrchestrator] == orchestratorLabelValue
+						isSameDeployment := curLabels[labelDeployment] == newLabels[labelDeployment]
+
+						return isManagedByEntropy && isSameDeployment
 					}
-					newLabels, ok := hc.Values[labelsConfKey].(map[string]string)
-					if !ok {
-						return false
+
+					helmCl := helm.NewClient(&helm.Config{Kubernetes: kubeConf})
+					_, errHelm := helmCl.Upsert(&hc, canUpdate)
+					return errHelm
+				},
+				kubeGetPod: func(ctx context.Context, conf kube.Config, ns string, labels map[string]string) ([]kube.Pod, error) {
+					kubeCl, err := kube.NewClient(ctx, conf)
+					if err != nil {
+						return nil, errors.ErrInternal.WithMsgf("failed to create new kube client on firehose driver kube get pod").WithCausef("%s", err.Error())
 					}
-
-					isManagedByEntropy := curLabels[labelOrchestrator] == orchestratorLabelValue
-					isSameDeployment := curLabels[labelDeployment] == newLabels[labelDeployment]
-
-					return isManagedByEntropy && isSameDeployment
-				}
-
-				helmCl := helm.NewClient(&helm.Config{Kubernetes: kubeConf})
-				_, errHelm := helmCl.Upsert(&hc, canUpdate)
-				return errHelm
-			},
-			kubeGetPod: func(ctx context.Context, conf kube.Config, ns string, labels map[string]string) ([]kube.Pod, error) {
-				kubeCl, err := kube.NewClient(ctx, conf)
-				if err != nil {
-					return nil, errors.ErrInternal.WithMsgf("failed to create new kube client on firehose driver kube get pod").WithCausef("%s", err.Error())
-				}
-				return kubeCl.GetPodDetails(ctx, ns, labels, func(pod v1.Pod) bool {
-					// allow pods that are in running state and are not marked for deletion
-					return pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil
-				})
-			},
-			kubeGetCRD: func(ctx context.Context, conf kube.Config, ns string, name string) (kube.FlinkDeploymentStatus, error) {
-				kubeCl, err := kube.NewClient(ctx, conf)
-				if err != nil {
-					return kube.FlinkDeploymentStatus{}, errors.ErrInternal.WithMsgf("failed to create new kube client on firehose driver kube get pod").WithCausef("%s", err.Error())
-				}
-				crd, err := kubeCl.GetCRDDetails(ctx, ns, name)
-				if err != nil {
-					return kube.FlinkDeploymentStatus{}, err
-				}
-				return parseFlinkCRDStatus(crd.Object)
-			},
-			kubeProxyService: func(ctx context.Context, conf kube.Config, namespace, scheme, serviceName, port, path string) (json.RawMessage, error) {
-				kubeCl, err := kube.NewClient(ctx, conf)
-				if err != nil {
-					return nil, errors.ErrInternal.WithMsgf("failed to create new kube client on dagger driver kube proxy service").WithCausef("%s", err.Error())
-				}
-				return kubeCl.ProxyService(ctx, namespace, scheme, serviceName, port, path, map[string]string{})
-			},
-			consumerReset: consumerReset,
-		}, nil
-	},
+					return kubeCl.GetPodDetails(ctx, ns, labels, func(pod v1.Pod) bool {
+						// allow pods that are in running state and are not marked for deletion
+						return pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil
+					})
+				},
+				kubeGetCRD: func(ctx context.Context, conf kube.Config, ns string, name string) (kube.FlinkDeploymentStatus, error) {
+					kubeCl, err := kube.NewClient(ctx, conf)
+					if err != nil {
+						return kube.FlinkDeploymentStatus{}, errors.ErrInternal.WithMsgf("failed to create new kube client on firehose driver kube get pod").WithCausef("%s", err.Error())
+					}
+					crd, err := kubeCl.GetCRDDetails(ctx, ns, name)
+					if err != nil {
+						return kube.FlinkDeploymentStatus{}, err
+					}
+					return parseFlinkCRDStatus(crd.Object)
+				},
+				kubeProxyService: func(ctx context.Context, conf kube.Config, namespace, scheme, serviceName, port, path string) (json.RawMessage, error) {
+					kubeCl, err := kube.NewClient(ctx, conf)
+					if err != nil {
+						return nil, errors.ErrInternal.WithMsgf("failed to create new kube client on dagger driver kube proxy service").WithCausef("%s", err.Error())
+					}
+					return kubeCl.ProxyService(ctx, namespace, scheme, serviceName, port, path, map[string]string{})
+				},
+				consumerReset: consumerReset,
+				getResource:   getResource,
+			}, nil
+		},
+	}
 }
 
 func parseFlinkCRDStatus(flinkDeployment map[string]interface{}) (kube.FlinkDeploymentStatus, error) {

--- a/modules/dagger/schema/config.json
+++ b/modules/dagger/schema/config.json
@@ -19,6 +19,43 @@
       "deployment_id": {
         "type": "string"
       },
+      "taskmanager_service_account": {
+        "type": "string"
+      },
+      "stream_security": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "security_protocol": { "type": "string" },
+            "sasl_mechanism": { "type": "string" },
+            "ssl_protocol": { "type": "string" },
+            "ssl_truststore_type": { "type": "string" },
+            "ssl_cert_secret": { "type": "string" },
+            "ssl_truststore_password_details": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "secretName": { "type": "string" },
+                "key": { "type": "string" }
+              }
+            },
+            "acls": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "secretName": { "type": "string" },
+                  "usernameKey": { "type": "string" },
+                  "passwordKey": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      },
       "sink_type": {
         "type": "string",
         "enum": [

--- a/modules/kafka/config.go
+++ b/modules/kafka/config.go
@@ -16,13 +16,55 @@ var (
 )
 
 type Config struct {
-	Entity        string        `json:"entity,omitempty"`
-	Environment   string        `json:"environment,omitempty"`
-	Landscape     string        `json:"landscape,omitempty"`
-	Organization  string        `json:"organization,omitempty"`
-	AdvertiseMode AdvertiseMode `json:"advertise_mode"`
-	Brokers       []Broker      `json:"brokers,omitempty"`
-	Type          string        `json:"type"`
+	Entity        string           `json:"entity,omitempty"`
+	Environment   string           `json:"environment,omitempty"`
+	Landscape     string           `json:"landscape,omitempty"`
+	Organization  string           `json:"organization,omitempty"`
+	AdvertiseMode AdvertiseMode    `json:"advertise_mode"`
+	Brokers       []Broker         `json:"brokers,omitempty"`
+	Type          string           `json:"type"`
+	Security      *SecurityProfile `json:"security,omitempty"`
+}
+
+// SecurityProfile carries the optional SASL/SSL authentication details for a
+// stream. When nil (or empty SecurityProtocol), the stream is treated as a
+// plaintext stream and behaves exactly as before. Only references to secrets
+// are stored here — never inline secret values.
+type SecurityProfile struct {
+	// SecurityProtocol is the Kafka security.protocol, e.g. SASL_SSL,
+	// SASL_PLAINTEXT, SSL or empty/PLAINTEXT.
+	SecurityProtocol string `json:"security_protocol,omitempty"`
+	// SaslMechanism is the SASL mechanism, e.g. OAUTHBEARER, PLAIN,
+	// SCRAM-SHA-512.
+	SaslMechanism string `json:"sasl_mechanism,omitempty"`
+	// SSLProtocol is the ssl.protocol, e.g. SSL / TLS.
+	SSLProtocol string `json:"ssl_protocol,omitempty"`
+	// SSLTruststoreType is the truststore type, e.g. PKCS12 or JKS.
+	SSLTruststoreType string `json:"ssl_truststore_type,omitempty"`
+	// SSLCertSecret is the name of the K8s secret holding the truststore/certs.
+	SSLCertSecret string `json:"ssl_cert_secret,omitempty"`
+	// SSLTruststorePasswordDetails references the secret + key holding the
+	// truststore password.
+	SSLTruststorePasswordDetails *SecretKeyRef `json:"ssl_truststore_password_details,omitempty"`
+	// ACLs holds per-team credential references for PLAIN/SCRAM mechanisms,
+	// keyed by team/group. References only — never inline secret values.
+	ACLs map[string]ACLCredentialRef `json:"acls,omitempty"`
+}
+
+// SecretKeyRef is a reference to a single key inside a K8s secret.
+type SecretKeyRef struct {
+	SecretName string `json:"secretName,omitempty"`
+	Key        string `json:"key,omitempty"`
+}
+
+// ACLCredentialRef references the secret material for a PLAIN/SCRAM credential.
+// It never carries inline username/password values.
+type ACLCredentialRef struct {
+	// SecretName is the K8s secret holding the credential material.
+	SecretName string `json:"secretName,omitempty"`
+	// UsernameKey / PasswordKey are the keys inside SecretName.
+	UsernameKey string `json:"usernameKey,omitempty"`
+	PasswordKey string `json:"passwordKey,omitempty"`
 }
 
 type AdvertiseMode struct {

--- a/modules/kafka/driver.go
+++ b/modules/kafka/driver.go
@@ -21,6 +21,10 @@ type kafkaDriver struct {
 
 type Output struct {
 	URL string `json:"url"`
+	// Security exposes the stream's optional security profile so dependents
+	// (e.g. the dagger module) can build the SASL/SSL consumer config. Nil for
+	// plaintext streams.
+	Security *SecurityProfile `json:"security,omitempty"`
 }
 
 type driverConf struct {
@@ -47,7 +51,8 @@ func (m *kafkaDriver) Plan(ctx context.Context, res module.ExpandedResource,
 	res.Resource.State = resource.State{
 		Status: resource.StatusCompleted,
 		Output: modules.MustJSON(Output{
-			URL: mapUrl(cfg),
+			URL:      mapUrl(cfg),
+			Security: cfg.Security,
 		}),
 	}
 
@@ -69,7 +74,8 @@ func (m *kafkaDriver) Output(ctx context.Context, res module.ExpandedResource) (
 	}
 
 	return modules.MustJSON(Output{
-		URL: mapUrl(cfg),
+		URL:      mapUrl(cfg),
+		Security: cfg.Security,
 	}), nil
 }
 

--- a/modules/kafka/schema/config.json
+++ b/modules/kafka/schema/config.json
@@ -48,6 +48,57 @@
         },
         "organization": {
             "type": "string"
+        },
+        "security": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+                "security_protocol": {
+                    "type": "string"
+                },
+                "sasl_mechanism": {
+                    "type": "string"
+                },
+                "ssl_protocol": {
+                    "type": "string"
+                },
+                "ssl_truststore_type": {
+                    "type": "string"
+                },
+                "ssl_cert_secret": {
+                    "type": "string"
+                },
+                "ssl_truststore_password_details": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "secretName": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "acls": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                            "secretName": {
+                                "type": "string"
+                            },
+                            "usernameKey": {
+                                "type": "string"
+                            },
+                            "passwordKey": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/modules/kubernetes/module.go
+++ b/modules/kubernetes/module.go
@@ -20,8 +20,7 @@ var Module = module.Descriptor{
 	},
 	DriverFactory: func(conf json.RawMessage) (module.Driver, error) {
 		kd := &kubeDriver{}
-		err := json.Unmarshal(conf, &kd)
-		if err != nil {
+		if err := json.Unmarshal(conf, kd); err != nil {
 			return nil, errors.ErrInvalid.WithMsgf("failed to unmarshal module config: %v", err)
 		}
 		return kd, nil


### PR DESCRIPTION
Entropy PR:
  - Three kafka security resolution paths (inline → dependency → flag+fetch)
  - Support for OAUTHBEARER, SASL_SSL, TLS, and PLAIN/SCRAM protocols
  - Implementation of resolveSourceStreams, buildAdditionalConfigurations, buildACLMounts
  - ACL volume/mount rendering and Flink configuration generation
  - Backward compatibility for plaintext sources